### PR TITLE
Add smoke tests for kiosk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 local_settings.py
 db.sqlite3
+postgres-data/
 media
 migrations/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+# Use containers instead of full VMs for faster startup.
+sudo: false
+
+language: python
+python:
+  - "3.6"
+install:
+  - "pip install -r requirements/development.txt"
+script:
+  - "python manage.py test"

--- a/ExCSystem/tests/test_views.py
+++ b/ExCSystem/tests/test_views.py
@@ -9,12 +9,12 @@ class ViewTestCase(TestCase):
 
 
 class SmokeTest(ViewTestCase):
+    """Redirect user to login page with 'follow' since not logged in"""
     def test_home_page_status_code(self):
         reseponse = self.client.get('/kiosk', follow=True)
         self.assertStatusCode(reseponse)
 
     def test_view_url_by_name(self):
-        """Redirect user to login page since not logged in"""
         response = self.client.get(reverse('home'), follow=True)
         self.assertStatusCode(response)
 

--- a/ExCSystem/tests/test_views.py
+++ b/ExCSystem/tests/test_views.py
@@ -9,7 +9,15 @@ class ViewTestCase(TestCase):
 
 
 class SmokeTest(ViewTestCase):
+    def test_home_page_status_code(self):
+        reseponse = self.client.get('/kiosk', follow=True)
+        self.assertStatusCode(reseponse)
+
     def test_view_url_by_name(self):
         """Redirect user to login page since not logged in"""
         response = self.client.get(reverse('home'), follow=True)
-        self.assertStatusCode(response, 200)
+        self.assertStatusCode(response)
+
+    def test_view_uses_correct_template(self):
+        response = self.client.get(reverse('home'), follow=True)
+        self.assertTemplateUsed(response, 'registration/login.html')

--- a/ExCSystem/tests/test_views.py
+++ b/ExCSystem/tests/test_views.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from django.urls import reverse
+from kiosk import views
+
+
+class ViewTestCase(TestCase):
+    def assertStatusCode(self, response, code=200):
+        self.assertEqual(response.status_code, code)
+
+
+class SmokeTest(ViewTestCase):
+    def test_kiosk(self):
+        response = self.client.get(reverse('kiosk'))
+        self.assertStatusCode(response)

--- a/ExCSystem/tests/test_views.py
+++ b/ExCSystem/tests/test_views.py
@@ -9,6 +9,7 @@ class ViewTestCase(TestCase):
 
 
 class SmokeTest(ViewTestCase):
-    def test_kiosk(self):
-        response = self.client.get(reverse('kiosk'))
-        self.assertStatusCode(response)
+    def test_home(self):
+        """Redirect user to login page since not logged in"""
+        response = self.client.get(reverse('home'))
+        self.assertStatusCode(response, code=302)

--- a/ExCSystem/tests/test_views.py
+++ b/ExCSystem/tests/test_views.py
@@ -9,7 +9,7 @@ class ViewTestCase(TestCase):
 
 
 class SmokeTest(ViewTestCase):
-    def test_home(self):
+    def test_view_url_by_name(self):
         """Redirect user to login page since not logged in"""
-        response = self.client.get(reverse('home'))
-        self.assertStatusCode(response, code=302)
+        response = self.client.get(reverse('home'), follow=True)
+        self.assertStatusCode(response, 200)

--- a/ExCSystem/urls.py
+++ b/ExCSystem/urls.py
@@ -24,6 +24,6 @@ admin.site.index_title = 'Admin Home'
 # admin.site.index_template = path/to/the/template.html
 
 urlpatterns = [
-    path('admin/', admin.site.urls, name='admin'),
-    path('kiosk/', include('kiosk.urls'), name='kiosk'),
+    path('admin/', admin.site.urls),
+    path('kiosk/', include('kiosk.urls')),
 ]

--- a/ExCSystem/urls.py
+++ b/ExCSystem/urls.py
@@ -24,6 +24,6 @@ admin.site.index_title = 'Admin Home'
 # admin.site.index_template = path/to/the/template.html
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('kiosk/', include('kiosk.urls')),
+    path('admin/', admin.site.urls, name='admin'),
+    path('kiosk/', include('kiosk.urls'), name='kiosk'),
 ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ExCSystem
+# ExCSystem [![Build Status](https://travis-ci.org/ExcursionClub/ExCSystem.svg?branch=master)](https://travis-ci.org/ExcursionClub/ExCSystem)
 
 Bottom up re-design of the Excursion system
 


### PR DESCRIPTION
Start adding tests for the kiosk

The smoke tests should always run since they're lightweight and catch breaking changes. Have all smoke tests under `/ExCSystem/tests` and method tests under `/<app>/tests`.
If the other tests are too heavy we can run them on the PR's instead of pre-commit.

Todo
- [x] Test url
- [x] Test template
- [x] Run tests automatically with Travis
- [x] Add Travis status badge