### PR TITLE
Fix PopulateDB bug

### DIFF
--- a/PopulateDatabase.py
+++ b/PopulateDatabase.py
@@ -3,6 +3,11 @@ from random import choice, randint
 from typing import Any, List, Optional, Union
 
 import django
+# Will raise an exception if not run here
+# django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ExCSystem.settings.development')
+django.setup()
+
 import kiosk.CheckoutLogic as logic
 import names
 import progressbar
@@ -14,8 +19,6 @@ from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.utils.timezone import timedelta
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ExCSystem.settings.development')
-django.setup()
 
 ADMIN_RFID = '0000000000'
 SYSTEM_RFID = '1111111111'

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ $ python3 RestartDatabase.py
 $ python3 PopulateDatabase.py
 ```
 
-This will wipe everything that exists in the database, and generate random data for the new database
+This will wipe everything that exists in the database, and generate random data for the new database.
 
 The server is now set up, and ready to run as if this was the first time
-ever running the project, though with the database populated with dummy data
+ever running the project, though with the database populated with dummy data. Running `PopulateDatabase.py` twice won't work as it tries to add users with the same RFID and that would violate the unique contstraint on the database.
 
 NOTE: Neither the database, nor anything in the migrations directory
 should ever be pushed to the git repo. The migrations directory on the


### PR DESCRIPTION
Before when running `PopulateDatabase.py` it produced an error.
The bug was introduced in https://github.com/ExcursionClub/ExCSystem/pull/19 when the imports were reordered. Turns out automatic linting isn't always a good thing. Should write tests to see that important scripts like this doesn't break.

```
(venv) ➜  ExCSystem git:(master) ✗ python3 PopulateDatabase.py
Traceback (most recent call last):
  File "PopulateDatabase.py", line 8, in <module>
    import kiosk.CheckoutLogic as logic
  File "/Users/estensen/Developer/ExCSystem/kiosk/CheckoutLogic.py", line 3, in <module>
    from core.models.TransactionModels import Transaction
  File "/Users/estensen/Developer/ExCSystem/core/models/__init__.py", line 2, in <module>
    from .MemberModels import MemberManager, Member, Staffer
  File "/Users/estensen/Developer/ExCSystem/core/models/MemberModels.py", line 6, in <module>
    from django.contrib.auth.models import BaseUserManager, AbstractBaseUser
  File "/Users/estensen/Developer/ExCSystem/venv/lib/python3.6/site-packages/django/contrib/auth/models.py", line 2, in <module>
    from django.contrib.auth.base_user import AbstractBaseUser, BaseUserManager
  File "/Users/estensen/Developer/ExCSystem/venv/lib/python3.6/site-packages/django/contrib/auth/base_user.py", line 47, in <module>
    class AbstractBaseUser(models.Model):
  File "/Users/estensen/Developer/ExCSystem/venv/lib/python3.6/site-packages/django/db/models/base.py", line 100, in __new__
    app_config = apps.get_containing_app_config(module)
  File "/Users/estensen/Developer/ExCSystem/venv/lib/python3.6/site-packages/django/apps/registry.py", line 244, in get_containing_app_config
    self.check_apps_ready()
  File "/Users/estensen/Developer/ExCSystem/venv/lib/python3.6/site-packages/django/apps/registry.py", line 127, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```