### PR TITLE
Upgrade Django and Pillow

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-django==2.0.4
+django==2.0.7
 django-phonenumber-field==2.0.0
 names==0.3.0
 progressbar2==3.34.3
-pillow==5.0.0
+pillow==5.2.0


### PR DESCRIPTION
Upgrade Pillow to support Python 3.7 so I don't have to reinstall 3.6