### PR TITLE
Real emails

### DIFF
--- a/ExCSystem/settings/development.py
+++ b/ExCSystem/settings/development.py
@@ -15,6 +15,7 @@ MEDIA_URL = '/media/'
 # Email host settings
 EMAIL_HOST = 'localhost'
 EMAIL_PORT = 1024
+MEMBERSHIP_EMAIL_HOST_USER = 'membership@ExCDev.org'
 
 # Base address of where the page is available
 WEB_BASE = "http://127.0.0.1:8000"

--- a/ExCSystem/settings/production.py
+++ b/ExCSystem/settings/production.py
@@ -19,8 +19,12 @@ DATABASES = {
 }
 
 # Email host settings
-EMAIL_HOST = 'email-smtp.us-west-2.amazonaws.com'
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_USE_TLS = True
 EMAIL_PORT = 587
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 
 # Base address of where the page is available
 WEB_BASE = "http://34.243.50.198"

--- a/ExCSystem/settings/production.py
+++ b/ExCSystem/settings/production.py
@@ -20,11 +20,11 @@ DATABASES = {
 
 # Email host settings
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST = 'smtp.1and1.com'
 EMAIL_USE_TLS = True
 EMAIL_PORT = 587
-EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
+MEMBERSHIP_EMAIL_HOST_USER = os.environ.get('MEMBERSHIP_EMAIL_HOST_USER')
+MEMBERSHIP_EMAIL_HOST_PASSWORD = os.environ.get('MEMBERSHIP_EMAIL_HOST_PASSWORD')
 
 # Base address of where the page is available
 WEB_BASE = "http://34.243.50.198"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ $ git clone git@github.com:TomekFraczek/ExCSystem.git && cd ExCSystem/
 $ docker-compose up -d
 ```
 
+### Emails
+Several parts of the project send out emails (i.e. when creating a new user). These processes will generally 
+crash if an email server is not set up. For setup of the production email server, see the deployment section below. 
+During development however, the easiest way is to use a local SMTP server to handle the emails. This can be done in the
+command line with:
+```bash
+python -m smtpd -n -c DebuggingServer localhost:1024
+```
+This command creates a tiny little local SMTP server on port 1024, that will print any emails
+received out to the command line. Just keep that window open and you're golden.
+
+If you'd like something a little more powerful, and with a GUI, then I recommend 
+http://nilhcem.com/FakeSMTP/.  Just make sure it is up and running on port 1024, and you'll receive any emails the 
+system sends.
+
+
 ## Development
 ### Linting
 Use type hints to statically check types. These are optional, but serves as up-to-date documentation and can catch errors in deeply nested objects. Check a file by running
@@ -84,7 +100,7 @@ when running the `makemigrations` and `migrate` commands. In the early
 stages, you can safely and easily reset the entire database from scratch
 using the ResetDatabase.py file.
 
-To restart he database:
+To restart the database:
 
 ```bash
 $ python3 RestartDatabase.py
@@ -195,12 +211,24 @@ grant ALL ON database excsystem to admin;
 pip3 install -r requirements/production.txt
 ```
 
-### Move env vars to .bashrc
+### Prepare Environment variables
+Django requires some sensitive information that should not be made available here on git. This information is stored in 
+environment variables on the server. To create these:
+
 ```
 export DJANGO_SECRET_KEY=
+```
+Login data to the database
+```
 export POSTGRES_USER=admin
 export POSTGRES_PASSWORD=
 ```
+login data to the email server(s)
+```
+export MEMBERSHIP_EMAIL_HOST_USER=
+export MEMBERSHIP_EMAIL_HOST_PASSWORD=
+```
+
 
 ### Create folders for static files
 ```

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -7,6 +7,8 @@ from django.contrib.auth.models import BaseUserManager, AbstractBaseUser, Group,
 
 from phonenumber_field.modelfields import PhoneNumberField
 
+from ExCSystem import settings
+
 from .CertificationModels import Certification
 from .fields.RFIDField import RFIDField
 
@@ -186,7 +188,7 @@ class Member(AbstractBaseUser):
         template_file = open(os.path.join(templates_dir, 'emails', 'intro_email.txt'))
         template = template_file.read()
         body = template.format(finish_signup_url=finish_signup_url)
-        self.send_email(title, body, from_email='membership@excursionclubucsb.org')
+        self.send_email(title, body, from_email=settings.MEMBERSHIP_EMAIL_HOST_USER)
 
     def has_perm(self, perm, obj=None):
         if '.' in perm:


### PR DESCRIPTION
Added configuration for sending real emails to real email addresses

Use the django built-in SMTP backend to send emails via the current excursion SMTP server (1&1). Currently only membership emails are configured, but they're also the only email being sent so...

Created env variables on the server to store the login info for the membersip email account