### PR TITLE
Dynamic Gear Types

### DIFF
--- a/PopulateDatabase.py
+++ b/PopulateDatabase.py
@@ -288,7 +288,10 @@ custom_fields = []
 for field_name in field_data.keys():
     field = CustomDataField(
         name=field_name,
-        data_type=field_data[field_name]['data_type']
+        data_type=field_data[field_name]['data_type'],
+        label=field_data[field_name]['label'],
+        required=field_data[field_name]['required'],
+        help_text=field_data[field_name]['help_text']
     )
     if 'suffix' in field_data[field_name].keys():
         field.suffix = field_data[field_name]['suffix']

--- a/PopulateDatabase.py
+++ b/PopulateDatabase.py
@@ -16,6 +16,7 @@ from core.models.DepartmentModels import Department
 from core.models.MemberModels import Member, Staffer
 from core.models.QuizModels import Question, Answer
 from core.models.TransactionModels import Transaction
+from core.models.GearModels import GearType, CustomDataField
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
@@ -210,10 +211,84 @@ for dept in departments:
 print('')
 print('Made departments')
 
-# Add gear
-print('Making Gear...')
-number_gear = 120
-gear_names = [
+# Add custom fields and gear_types
+field_data = {
+    "length": {
+        "data_type": "float",
+        "initial": 0,
+        "label": "length",
+        "name": "length",
+        "required": True,
+        "help_text": "The length of the item"
+    },
+    "capacity": {
+        "data_type": "int",
+        "initial": 0,
+        "label": "Number of people",
+        "name": "capacity",
+        "required": True,
+        "help_text": "The number of people that can fit inside",
+        "min_value": 0,
+        "max_value": 10
+    },
+    "size": {
+        "data_type": "choice",
+        "initial": "--",
+        "label": "Size",
+        "name": "size",
+        "required": True,
+        "help_text": "The size of the item",
+        "choices": (
+            ("--", "Please choose a size"),
+            ("S", "Small"),
+            ("M", "Medium"),
+            ("L", "Large")
+        )
+    },
+    "manufacturer": {
+        "data_type": "string",
+        "initial": "Unknown",
+        "label": "Manufacturer",
+        "name": "manufacturer",
+        "required": True,
+        "help_text": "Manufacturer of the item",
+        "min_length": 2,
+        "max_length": 30
+    },
+    "is_special": {
+        "data_type": "boolean",
+        "initial": False,
+        "label": "Is special",
+        "name": "is_special",
+        "required": False,
+        "help_text": "Is this a 'special' item?"
+    },
+    "a_rfid": {
+        "data_type": "rfid",
+        "initial": None,
+        "label": "a rfid to something",
+        "name": "a_rfid",
+        "required": True,
+        "help_text": "Not sure for what, but if you need a rfid"
+    },
+    "owner": {
+        "data_type": "reference",
+        "initial": None,
+        "label": "Object Owner",
+        "name": "owner",
+        "required": False,
+        "help_text": "The real owner of this item",
+        "pk": None,
+        "object_type": Staffer,
+    },
+}
+custom_fields = []
+for field_name in field_data.keys():
+    field = CustomDataField(name=field_name, data_type=field_data[field_name]['data_type'])
+    field.save()
+    custom_fields.append(field)
+
+gear_type_names = [
     'Sleeping Bag',
     'Sleeping Pad',
     'Tent',
@@ -236,17 +311,32 @@ gear_names = [
     'Wetsuit',
 ]
 departments = Department.objects.all()
+gear_types = []
+print("Making Gear Types")
+bar = progressbar.ProgressBar()
+for name in bar(gear_type_names):
+    gear_type = GearType(
+        name=name,
+        department=pick_random(departments),
+    )
+    gear_type.save()
+    # Add between 1 and 3 custom fields
+    for i in range(1, randint(2, 4)):
+        gear_type.data_fields.add(pick_random(custom_fields))
+    gear_type.save()
+    gear_types.append(gear_type)
+
+# Add gear
+print('Making Gear...')
+number_gear = 120
+
 gear_rfids = []
 bar = progressbar.ProgressBar()
 for i in bar(range(number_gear)):
     gear_rfid = gen_rfid()
     authorizer: str = pick_random(staffer_rfids)
-    gear_name: str = pick_random(gear_names)
-    department = pick_random(
-        departments
-    )  # TODO: Make this not be randomly assigned cause ie skis are not wetsuits
-
-    transaction, gear = Transaction.objects.add_gear(authorizer, gear_rfid, gear_name, department)
+    gear_type = pick_random(gear_types)
+    transaction, gear = Transaction.objects.add_gear(authorizer, gear_rfid, gear_type, **field_data)
     gear_rfids.append(gear_rfid)
 
 print('')
@@ -272,9 +362,9 @@ print('{} out of {} checkouts failed to complete'.format(n_failed_checkouts, n_g
 # Add gear with know RFID
 for gear_rfid in RFIDS_TO_HAND_OUT:
     authorizer = '1234567890'
-    gear_name = pick_random(gear_names)
     department = pick_random(departments)
-    transaction, gear = Transaction.objects.add_gear(authorizer, gear_rfid, gear_name, department)
+    gear_type = pick_random(gear_types)
+    transaction, gear = Transaction.objects.add_gear(authorizer, gear_rfid, gear_type, **field_data)
     gear_rfids.append(gear_rfid)
 
 # Check out gear with known RFID

--- a/PopulateDatabase.py
+++ b/PopulateDatabase.py
@@ -273,16 +273,6 @@ field_data = {
         "required": True,
         "help_text": "Not sure for what, but if you need a rfid"
     },
-    "owner": {
-        "data_type": "reference",
-        "initial": None,
-        "label": "Object Owner",
-        "name": "owner",
-        "required": False,
-        "help_text": "The real owner of this item",
-        "pk": None,
-        "object_type": Staffer,
-    },
 }
 custom_fields = []
 for field_name in field_data.keys():

--- a/PopulateDatabase.py
+++ b/PopulateDatabase.py
@@ -267,7 +267,7 @@ field_data = {
     },
     "a_rfid": {
         "data_type": "rfid",
-        "initial": None,
+        "initial": "",
         "label": "a rfid to something",
         "name": "a_rfid",
         "required": True,

--- a/PopulateDatabase.py
+++ b/PopulateDatabase.py
@@ -215,7 +215,8 @@ print('Made departments')
 field_data = {
     "length": {
         "data_type": "float",
-        "initial": 0,
+        "suffix": "cm",
+        "initial": 12.5,
         "label": "length",
         "name": "length",
         "required": True,
@@ -223,7 +224,8 @@ field_data = {
     },
     "capacity": {
         "data_type": "int",
-        "initial": 0,
+        "initial": 3,
+        "suffix": "person",
         "label": "Number of people",
         "name": "capacity",
         "required": True,
@@ -233,7 +235,7 @@ field_data = {
     },
     "size": {
         "data_type": "choice",
-        "initial": "--",
+        "initial": "S",
         "label": "Size",
         "name": "size",
         "required": True,
@@ -247,7 +249,7 @@ field_data = {
     },
     "manufacturer": {
         "data_type": "string",
-        "initial": "Unknown",
+        "initial": "Patagonia",
         "label": "Manufacturer",
         "name": "manufacturer",
         "required": True,
@@ -284,7 +286,12 @@ field_data = {
 }
 custom_fields = []
 for field_name in field_data.keys():
-    field = CustomDataField(name=field_name, data_type=field_data[field_name]['data_type'])
+    field = CustomDataField(
+        name=field_name,
+        data_type=field_data[field_name]['data_type']
+    )
+    if 'suffix' in field_data[field_name].keys():
+        field.suffix = field_data[field_name]['suffix']
     field.save()
     custom_fields.append(field)
 
@@ -320,8 +327,8 @@ for name in bar(gear_type_names):
         department=pick_random(departments),
     )
     gear_type.save()
-    # Add between 1 and 3 custom fields
-    for i in range(1, randint(2, 4)):
+    # Add between 1 and 4 custom fields
+    for i in range(1, randint(2, 5)):
         gear_type.data_fields.add(pick_random(custom_fields))
     gear_type.save()
     gear_types.append(gear_type)

--- a/buildPermissions.py
+++ b/buildPermissions.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from core.models.CertificationModels import Certification
 from core.models.DepartmentModels import Department
 from core.models.MemberModels import Member, Staffer
-from core.models.GearModels import Gear
+from core.models.GearModels import Gear, GearType, CustomDataField
 from core.models.TransactionModels import Transaction
 from core.models.QuizModels import Question, Answer
 
@@ -22,6 +22,8 @@ member_type = ContentType.objects.get_for_model(Member)
 staffer_type = ContentType.objects.get_for_model(Staffer)
 transaction_type = ContentType.objects.get_for_model(Transaction)
 gear_type = ContentType.objects.get_for_model(Gear)
+geartype_type = ContentType.objects.get_for_model(GearType)
+custom_field_type = ContentType.objects.get_for_model(CustomDataField)
 group_type = ContentType.objects.get_for_model(Group)
 question_type = ContentType.objects.get_for_model(Question)
 answer_type = ContentType.objects.get_for_model(Answer)
@@ -121,6 +123,11 @@ def build_staffer():
         codename="change_member",
         name="Can do arbitrary changes to members",
         content_type=member_type)
+    add_permission(
+        codename="view_gear_type",
+        name="Can view gear types",
+        content_type=geartype_type
+    )
     staffer.permissions.set(all_permissions)
     staffer.save()
 
@@ -136,6 +143,36 @@ def build_board():
         codename="remove_gear",
         name="Can set gear to removed status",
         content_type=gear_type
+    )
+    add_permission(
+        codename="change_geartype",
+        name="Can change gear types",
+        content_type=geartype_type
+    )
+    add_permission(
+        codename="add_geartype",
+        name="Can change gear types",
+        content_type=geartype_type
+    )
+    add_permission(
+        codename="delete_geartype",
+        name="Can delete gear types",
+        content_type=geartype_type
+    )
+    add_permission(
+        codename="add_customdatafield",
+        name="Can add custom data fields",
+        content_type=custom_field_type
+    )
+    add_permission(
+        codename="change_customdatafield",
+        name="Can change custom data fields",
+        content_type=custom_field_type
+    )
+    add_permission(
+        codename="delete_customdatafield",
+        name="Can delete custom data fields",
+        content_type=custom_field_type
     )
     add_permission(
         codename="add_staffer",

--- a/buildPermissions.py
+++ b/buildPermissions.py
@@ -145,11 +145,6 @@ def build_board():
         content_type=gear_type
     )
     add_permission(
-        codename="change_geartype",
-        name="Can change gear types",
-        content_type=geartype_type
-    )
-    add_permission(
         codename="add_geartype",
         name="Can change gear types",
         content_type=geartype_type

--- a/core/admin/ExcAdminSite.py
+++ b/core/admin/ExcAdminSite.py
@@ -62,7 +62,7 @@ class ExcursionAdmin(AdminSite):
 
             if perms.get('add'):
                 try:
-                    model_dict['add_url'] = reverse(f'admin{app_label}_{model_name}_add', current_app=self.name)
+                    model_dict['add_url'] = reverse(f'admin:{app_label}_{model_name}_add', current_app=self.name)
                 except NoReverseMatch:
                     pass
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -4,10 +4,10 @@ from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailVie
 
 class GearAdmin(ViewableModelAdmin):
     # Make all the data about a certification be shown in the list display
-    list_display = ("name", "gear_type", "status", "checked_out_to", "due_date")
+    list_display = ("name", "geartype", "status", "checked_out_to", "due_date")
 
     # Choose which fields appear on the side as filters
-    list_filter = ('status', "gear_type", "gear_type__department")
+    list_filter = ('status', "geartype", "geartype__department")
 
     # Choose which fields can be searched for
     search_fields = ('name', 'rfid', "checked_out_to__first_name", "checked_out_to__last_name")
@@ -15,7 +15,7 @@ class GearAdmin(ViewableModelAdmin):
     fieldsets = (
         ('Gear Info', {
             'classes': ('wide',),
-            'fields': ("rfid", "name", "gear_type"),
+            'fields': ("rfid", "name", "geartype"),
         }),
         ('Checkout Info', {
             'classes': ('wide',),

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -7,7 +7,7 @@ class GearAdmin(ViewableModelAdmin):
     list_display = ("name", "geartype", "status", "checked_out_to", "due_date")
 
     # Choose which fields appear on the side as filters
-    list_filter = ('status', "geartype", "geartype__department")
+    list_filter = ('status', "geartype__department", "geartype")
 
     # Choose which fields can be searched for
     search_fields = ('name', 'rfid', "checked_out_to__first_name", "checked_out_to__last_name")

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.contrib.admin.utils import quote
+from django.contrib.admin import ModelAdmin
 
 from core.admin.ViewableAdmin import ViewableModelAdmin
 from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailView
@@ -101,4 +102,10 @@ class GearTypeAdmin(ViewableModelAdmin):
         """No one should have permissions to change gear types, it'll guaranteed destroy data"""
         return False
 
+
+class CustomDataFieldAdmin(ModelAdmin):
+    """Forbid anyone from changing CustomDataFields"""
+
+    def has_change_permission(self, request, obj=None):
+        return False
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -20,6 +20,10 @@ class GearAdmin(ViewableModelAdmin):
         ('Checkout Info', {
             'classes': ('wide',),
             'fields': ("status", "checked_out_to", "due_date")
+        }),
+        ('Additional Info', {
+            'classes': ('wide', ),
+            'fields': ('gear_data',)
         })
     )
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -4,7 +4,7 @@ from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailVie
 
 class GearAdmin(ViewableModelAdmin):
     # Make all the data about a certification be shown in the list display
-    list_display = ("name", "geartype", "status", "checked_out_to", "due_date")
+    list_display = ("name", "status", "get_department", "checked_out_to", "due_date")
 
     # Choose which fields appear on the side as filters
     list_filter = ('status', "geartype__department", "geartype")

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from core.admin.ViewableAdmin import ViewableModelAdmin
 from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailView
-from core.forms.GearForms import GearChangeForm, GearAddFormStart
+from core.forms.GearForms import GearChangeForm, GearAddForm
 
 
 class GearAdmin(ViewableModelAdmin):
@@ -29,8 +29,7 @@ class GearAdmin(ViewableModelAdmin):
     ]
 
     form = GearChangeForm
-    initial_add_form = GearAddFormStart
-    finish_add_form = GearChangeForm  # Hijack gear change to finalize the addition process TODO: Might want dedicated
+    add_form = GearAddForm
 
     list_view = GearViewList
     detail_view_class = GearDetailView
@@ -72,7 +71,7 @@ class GearAdmin(ViewableModelAdmin):
         else:
             # Load the add form, including an empty (required) attributes
             new_attrs = OrderedDict()
-            add_form = type(self.initial_add_form.__name__, (self.initial_add_form,), new_attrs)
+            add_form = type(self.add_form.__name__, (self.add_form,), new_attrs)
             add_form.authorizer_rfid = request.user.rfid
             return super(GearAdmin, self).get_form(request, obj=None, form=add_form, **kwargs)
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -52,7 +52,7 @@ class GearAdmin(ViewableModelAdmin):
         # For each dynamic field, add it to declared fields and the fields list (returned here)
         for field in extra_fields:
             field_data = gear_data[field.name]
-            form_field = field.get_field(field_data)
+            form_field = field.get_field(**field_data)
             extended_form.declared_fields.update({field.name: form_field})
         return super(GearAdmin, self).get_form(request, obj=obj, form=extended_form, **kwargs)
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -53,6 +53,7 @@ class GearAdmin(ViewableModelAdmin):
             # Load the basic form, including an empty (required) attributes
             new_attrs = OrderedDict()
             extended_form = type(self.form.__name__, (self.form,), new_attrs)
+            extended_form.authorizer_rfid = request.user.rfid
 
             # Load all the fields that need to be added dynamically from the geartype
             gear_data = json.loads(obj.gear_data)
@@ -72,6 +73,7 @@ class GearAdmin(ViewableModelAdmin):
             # Load the add form, including an empty (required) attributes
             new_attrs = OrderedDict()
             add_form = type(self.initial_add_form.__name__, (self.initial_add_form,), new_attrs)
+            add_form.authorizer_rfid = request.user.rfid
             return super(GearAdmin, self).get_form(request, obj=None, form=add_form, **kwargs)
 
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -36,7 +36,7 @@ class GearAdmin(ViewableModelAdmin):
     def get_fieldsets(self, request, obj=None):
         """Add in the dynamic fields defined by geartype into the fieldsets (so django knows how to display them)"""
         fieldsets = super(GearAdmin, self).get_fieldsets(request, obj=obj)
-        fieldsets += [obj.get_extra_fieldset()]  # Using append results in multiple copies of the extra fields
+        fieldsets = fieldsets + [obj.get_extra_fieldset()]  # Using append gives multiple copies of the extra fields
         return tuple(fieldsets)
     
     def get_form(self, request, obj=None, **kwargs):
@@ -55,10 +55,6 @@ class GearAdmin(ViewableModelAdmin):
             form_field = field.get_field(field_data)
             extended_form.declared_fields.update({field.name: form_field})
         return super(GearAdmin, self).get_form(request, obj=obj, form=extended_form, **kwargs)
-
-    # Add the extra fields specified by the gear type to fieldsets
-    def change_view(self, request, object_id, form_url='', extra_context=None):
-        return super(GearAdmin, self).change_view(request, object_id, form_url=form_url)
 
 
 class GearTypeAdmin(ViewableModelAdmin):

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -1,5 +1,5 @@
 from core.admin.ViewableAdmin import ViewableModelAdmin
-from core.views.GearViews import GearDetailView, GearViewList
+from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailView
 
 
 class GearAdmin(ViewableModelAdmin):
@@ -25,4 +25,9 @@ class GearAdmin(ViewableModelAdmin):
 
     list_view = GearViewList
     detail_view_class = GearDetailView
+
+
+class GearTypeAdmin(ViewableModelAdmin):
+    detail_view_class = GearTypeDetailView
+
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -1,6 +1,9 @@
 import json
 
 from collections import OrderedDict
+from django.urls import reverse
+from django.http import HttpResponseRedirect
+from django.contrib.admin.utils import quote
 
 from core.admin.ViewableAdmin import ViewableModelAdmin
 from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailView
@@ -74,6 +77,14 @@ class GearAdmin(ViewableModelAdmin):
             add_form = type(self.add_form.__name__, (self.add_form,), new_attrs)
             add_form.authorizer_rfid = request.user.rfid
             return super(GearAdmin, self).get_form(request, obj=None, form=add_form, **kwargs)
+
+    def response_add(self, request, obj, post_url_continue=None):
+        """After adding a new piece of gear, always go to the 'change' page to finish filling out gear data"""
+        change_url = reverse(
+            f'admin:{obj._meta.app_label}_{obj._meta.model_name}_change',
+            args=(quote(obj.pk),),
+            current_app=self.admin_site.name,)
+        return HttpResponseRedirect(change_url)
 
 
 class GearTypeAdmin(ViewableModelAdmin):

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -15,7 +15,7 @@ class GearAdmin(ViewableModelAdmin):
     fieldsets = (
         ('Gear Info', {
             'classes': ('wide',),
-            'fields': ("rfid", "name", "geartype"),
+            'fields': ("rfid", "geartype"),
         }),
         ('Checkout Info', {
             'classes': ('wide',),

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -4,10 +4,10 @@ from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailVie
 
 class GearAdmin(ViewableModelAdmin):
     # Make all the data about a certification be shown in the list display
-    list_display = ("name", "department", "status", "checked_out_to", "due_date")
+    list_display = ("name", "gear_type", "status", "checked_out_to", "due_date")
 
     # Choose which fields appear on the side as filters
-    list_filter = ('status', "department")
+    list_filter = ('status', "gear_type")
 
     # Choose which fields can be searched for
     search_fields = ('name', 'rfid', "checked_out_to__first_name", "checked_out_to__last_name")
@@ -15,7 +15,7 @@ class GearAdmin(ViewableModelAdmin):
     fieldsets = (
         ('Gear Info', {
             'classes': ('wide',),
-            'fields': ("rfid", "name", "department"),
+            'fields': ("rfid", "name", "gear_type"),
         }),
         ('Checkout Info', {
             'classes': ('wide',),

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -88,6 +88,17 @@ class GearAdmin(ViewableModelAdmin):
 
 
 class GearTypeAdmin(ViewableModelAdmin):
+    """
+    Admin class to make gear types viewable
+
+    Since gear types have on_delete set to CASCADE, if a gear type has been used on a piece of gear (and is therefore
+    referenced in transaction), no-one will be able to delete that gear type, since deleting Transactions is explicitly
+    forbidden for all users, including admin
+    """
     detail_view_class = GearTypeDetailView
+
+    def has_change_permission(self, request, obj=None):
+        """No one should have permissions to change gear types, it'll guaranteed destroy data"""
+        return False
 
 

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -7,7 +7,7 @@ class GearAdmin(ViewableModelAdmin):
     list_display = ("name", "gear_type", "status", "checked_out_to", "due_date")
 
     # Choose which fields appear on the side as filters
-    list_filter = ('status', "gear_type")
+    list_filter = ('status', "gear_type", "gear_type__department")
 
     # Choose which fields can be searched for
     search_fields = ('name', 'rfid', "checked_out_to__first_name", "checked_out_to__last_name")

--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from core.admin.ViewableAdmin import ViewableModelAdmin
 from core.views.GearViews import GearDetailView, GearViewList, GearTypeDetailView
-from core.forms.GearForms import GearChangeForm
+from core.forms.GearForms import GearChangeForm, GearAddFormStart
 
 
 class GearAdmin(ViewableModelAdmin):
@@ -29,6 +29,8 @@ class GearAdmin(ViewableModelAdmin):
     ]
 
     form = GearChangeForm
+    initial_add_form = GearAddFormStart
+    finish_add_form = GearChangeForm  # Hijack gear change to finalize the addition process TODO: Might want dedicated
 
     list_view = GearViewList
     detail_view_class = GearDetailView
@@ -36,25 +38,41 @@ class GearAdmin(ViewableModelAdmin):
     def get_fieldsets(self, request, obj=None):
         """Add in the dynamic fields defined by geartype into the fieldsets (so django knows how to display them)"""
         fieldsets = super(GearAdmin, self).get_fieldsets(request, obj=obj)
-        fieldsets = fieldsets + [obj.get_extra_fieldset()]  # Using append gives multiple copies of the extra fields
+
+        # Only get the extra fieldsets if we already have an object created
+        if obj:
+            fieldsets = fieldsets + [obj.get_extra_fieldset()]  # Using append gives multiple copies of the extra fields
+
         return tuple(fieldsets)
     
     def get_form(self, request, obj=None, **kwargs):
         """Manually insert the form fields for our dynamic fields into the admin form so the data can be edited"""
-        # Load the basic form, including an empty (required) attributes
-        new_attrs = OrderedDict()
-        extended_form = type(self.form.__name__, (self.form,), new_attrs)
 
-        # Load all the fields that need to be added dynamically from the geartype
-        gear_data = json.loads(obj.gear_data)
-        extra_fields = obj.geartype.data_fields.all()
+        # If an object was passed, then we are dealing with an object change situation, so all fields on one page
+        if obj:
+            # Load the basic form, including an empty (required) attributes
+            new_attrs = OrderedDict()
+            extended_form = type(self.form.__name__, (self.form,), new_attrs)
 
-        # For each dynamic field, add it to declared fields and the fields list (returned here)
-        for field in extra_fields:
-            field_data = gear_data[field.name]
-            form_field = field.get_field(**field_data)
-            extended_form.declared_fields.update({field.name: form_field})
-        return super(GearAdmin, self).get_form(request, obj=obj, form=extended_form, **kwargs)
+            # Load all the fields that need to be added dynamically from the geartype
+            gear_data = json.loads(obj.gear_data)
+            extra_fields = obj.geartype.data_fields.all()
+
+            # For each dynamic field, add it to declared fields and the fields list (returned here)
+            for field in extra_fields:
+                field_data = gear_data[field.name]
+                form_field = field.get_field(**field_data)
+                extended_form.declared_fields.update({field.name: form_field})
+            return super(GearAdmin, self).get_form(request, obj=obj, form=extended_form, **kwargs)
+
+        # If no obj was passed, assume we are creating a new object, so we split creation into two parts. The first part
+        # is just the default creation page with the default fields, the second page (based on gear type) is handled in
+        # one of the add response functions (see below)
+        else:
+            # Load the add form, including an empty (required) attributes
+            new_attrs = OrderedDict()
+            add_form = type(self.initial_add_form.__name__, (self.initial_add_form,), new_attrs)
+            return super(GearAdmin, self).get_form(request, obj=None, form=add_form, **kwargs)
 
 
 class GearTypeAdmin(ViewableModelAdmin):

--- a/core/admin/ViewableAdmin.py
+++ b/core/admin/ViewableAdmin.py
@@ -36,7 +36,7 @@ class ViewableModelAdmin(ModelAdmin):
         detail_view = detail.as_view()
         return wrap(detail_view)
 
-    def has_view_permission(self, request):
+    def has_view_permission(self, request, obj=None):
         opts = self.opts
         codename = get_permission_codename('view', opts)
         return request.user.has_perm(f'{opts.app_label}.{codename}')

--- a/core/admin/__init__.py
+++ b/core/admin/__init__.py
@@ -1,14 +1,14 @@
 from django.contrib.auth.models import Group
 
 from ..models.MemberModels import Member, Staffer
-from ..models.GearModels import Gear
+from ..models.GearModels import Gear, GearType, CustomDataField
 from ..models.TransactionModels import Transaction
 from ..models.CertificationModels import Certification
 from ..models.DepartmentModels import Department
 from ..models.QuizModels import Question, Answer
 
 from .MemberAdmin import MemberAdmin, StafferAdmin
-from .GearAdmin import GearAdmin
+from .GearAdmin import GearAdmin, GearTypeAdmin
 from .TransactionAdmin import TransactionAdmin
 from .OtherAdmins import CertificationAdmin, DepartmentAdmin
 
@@ -19,6 +19,8 @@ admin_site = ExcursionAdmin()
 
 # Register your models here.
 admin_site.register(Gear, GearAdmin)
+admin_site.register(GearType, GearTypeAdmin)
+admin_site.register(CustomDataField)
 admin_site.register(Transaction, TransactionAdmin)
 admin_site.register(Certification, CertificationAdmin)
 admin_site.register(Department, DepartmentAdmin)

--- a/core/admin/__init__.py
+++ b/core/admin/__init__.py
@@ -8,7 +8,7 @@ from ..models.DepartmentModels import Department
 from ..models.QuizModels import Question, Answer
 
 from .MemberAdmin import MemberAdmin, StafferAdmin
-from .GearAdmin import GearAdmin, GearTypeAdmin
+from .GearAdmin import GearAdmin, GearTypeAdmin, CustomDataFieldAdmin
 from .TransactionAdmin import TransactionAdmin
 from .OtherAdmins import CertificationAdmin, DepartmentAdmin
 
@@ -20,7 +20,7 @@ admin_site = ExcursionAdmin()
 # Register your models here.
 admin_site.register(Gear, GearAdmin)
 admin_site.register(GearType, GearTypeAdmin)
-admin_site.register(CustomDataField)
+admin_site.register(CustomDataField, CustomDataFieldAdmin)
 admin_site.register(Transaction, TransactionAdmin)
 admin_site.register(Certification, CertificationAdmin)
 admin_site.register(Department, DepartmentAdmin)

--- a/core/forms/GearForms.py
+++ b/core/forms/GearForms.py
@@ -1,3 +1,5 @@
+import json
+
 from django.forms import ModelForm
 
 from core.models.GearModels import Gear
@@ -14,4 +16,20 @@ class GearChangeForm(ModelForm):
 
         # Make gear type non-editable. Necessary to avoid data corruption
         self.fields["geartype"].disabled = True
+
+    def clean_gear_data(self):
+        """Compile the data from all the custom fields to be saved into gear_data"""
+        gear_data_dict = {}
+        original_gear_data = json.loads(self.instance.gear_data)
+        for name in self.declared_fields.keys():
+            value = self.cleaned_data[name]
+            field_data = original_gear_data[name]
+            field_data["initial"] = value
+            gear_data_dict[name] = field_data
+
+        return json.dumps(gear_data_dict)
+
+    def save(self, commit=True):
+        self.instance.gear_data = self.clean_gear_data()
+        return super(GearChangeForm, self).save(commit=commit)
 

--- a/core/forms/GearForms.py
+++ b/core/forms/GearForms.py
@@ -54,8 +54,8 @@ class GearAddFormStart(ModelForm):
     def __init__(self, *args, **kwargs):
         super(GearAddFormStart, self).__init__(*args, **kwargs)
         # Don't disable geartype, this is the only time it should be editable
-        # Disable status: when gear is created it should always be 'in stock'
-        self.fields["status"].disabled = True
+        # Set the default status to be in stock
+        self.fields["status"].initial = 0
 
     def clean_gear_data(self):
         """During the initial creation of the gear, the gear data JSON must be created."""

--- a/core/forms/GearForms.py
+++ b/core/forms/GearForms.py
@@ -1,0 +1,17 @@
+from django.forms import ModelForm
+
+from core.models.GearModels import Gear
+
+
+class GearChangeForm(ModelForm):
+
+    class Meta:
+        model = Gear
+        fields = '__all__'
+
+    def __init__(self, *args, **kwargs):
+        super(GearChangeForm, self).__init__(*args, **kwargs)
+
+        # Make gear type non-editable. Necessary to avoid data corruption
+        self.fields["geartype"].disabled = True
+

--- a/core/forms/GearForms.py
+++ b/core/forms/GearForms.py
@@ -32,6 +32,11 @@ class GearChangeForm(ModelForm):
         return json.dumps(gear_data_dict)
 
     def save(self, commit=True):
+        """Save using the Transactions instead of using the gear object directly"""
+
+        # Django really wants to call this function, even though it does nothing for gear
+        self.save_m2m = self._save_m2m
+
         self.cleaned_data['gear_data'] = self.clean_gear_data()
         gear_rfid = self.cleaned_data.pop('rfid')
         change_data = self.cleaned_data
@@ -64,7 +69,8 @@ class GearAddForm(ModelForm):
 
     def save(self, commit=True):
         """Save this new instance, making sure to use the Transaction method"""
-        # We will always commit the save, so make sure m2m fields are always saved
+
+        # Django really wants to call this function, even though it does nothing for gear
         self.save_m2m = self._save_m2m
 
         transaction, gear = Transaction.objects.add_gear(

--- a/core/forms/fields/RFIDField.py
+++ b/core/forms/fields/RFIDField.py
@@ -15,6 +15,8 @@ class RFIDField(forms.CharField):
 
     def to_python(self, value):
         """Validate the RFID string is in fact a valid RFID"""
+        if value is None:
+            value = ""
 
         if not value.isdigit():
             raise ValidationError("RFIDs may only contain the digits 0-9")

--- a/core/forms/widgets/CustomDataWidget.py
+++ b/core/forms/widgets/CustomDataWidget.py
@@ -1,0 +1,7 @@
+
+from django.forms.widgets import MultiWidget
+
+
+class CustomDataWidget(MultiWidget):
+
+

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -43,7 +43,7 @@ class CustomDataField(models.Model):
 
     name = models.CharField(max_length=30, unique=True)
     data_type = models.CharField(max_length=20, choices=data_types)
-    suffix = models.CharField(max_length=10, default="")
+    suffix = models.CharField(max_length=10, default="", blank=True)
     required = models.BooleanField(default=False)
     label = models.CharField(max_length=30, default="")
     help_text = models.CharField(max_length=200, default="")

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -109,8 +109,9 @@ class CustomDataField(models.Model):
         if object_type:
             kwargs['app_label'] = object_type._meta.app_label
             kwargs['model_name'] = object_type.__name__
-        elif 'app_label' in kwargs and 'model_name' in kwargs:
-            object_type = importlib.__import__(f"{kwargs['app_label']}.models", fromlist=(kwargs['model_name'],))
+        elif 'app_label' in kwargs.keys() and 'model_name' in kwargs.keys():
+            module = importlib.import_module(f"{kwargs['app_label']}.models")
+            object_type = getattr(module, kwargs['model_name'])
 
         if not selectable_objects:
             selectable_objects = object_type.objects.all()
@@ -118,8 +119,8 @@ class CustomDataField(models.Model):
         return {
             "initial": str(obj) if obj else None,
             "pk": obj.pk if obj else None,
-            "app_label": object_type._meta.app_label,
-            "model_name": object_type.__name__,
+            "app_label": kwargs['app_label'],
+            "model_name": kwargs['model_name'],
             "selectable_objects": serializers.serialize("json", selectable_objects)
         }
     

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -129,10 +129,7 @@ class CustomDataField(models.Model):
 
     def get_value(self, data_dict):
         """Returns the object currently stored by this field"""
-        if self.data_type == "choice":
-            selected = data_dict["initial"]
-        else:
-            return data_dict["initial"]
+        return data_dict["initial"]
 
     def get_str(self, data_dict):
         """Get the string representation of the value of this field"""

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -54,7 +54,7 @@ class CustomDataField(models.Model):
 
     name = models.CharField(max_length=30, unique=True)
     data_type = models.CharField(max_length=20, choices=data_types)
-    suffix = models.CharField(max_length=10)
+    suffix = models.CharField(max_length=10, default="")
     required = models.BooleanField(default=False)
     label = models.CharField(max_length=30, default="")
     help_text = models.CharField(max_length=200, default="")

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -7,7 +7,7 @@ from .DepartmentModels import Department
 from .CertificationModels import Certification
 
 from django.forms.widgets import TextInput, Textarea, NumberInput, CheckboxInput, Select
-from core.forms.widgets import RFIDWidget
+from core.forms.widgets.RFIDWidget import RFIDWidget
 
 from django.forms.fields import CharField, ChoiceField, IntegerField, FloatField, BooleanField
 from django.forms.models import ModelChoiceField

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -231,7 +231,6 @@ class GearType(models.Model):
         return data_dict
 
 
-
 class GearManager(models.Manager):
 
     def _create(self, rfid, gear_type, **gear_data):

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -129,9 +129,14 @@ class CustomDataField(models.Model):
     
     def get_reference_field(self, pk=None, app_label=None, model_name=None, selectable_objects=None, **init_data):
         object_type = apps.get_model(app_label, model_name)
-        init_data["initial"] = object_type.objects.get(pk=pk)
+        if pk:
+            init_data["initial"] = object_type.objects.get(pk=pk)
         if selectable_objects:
-            selectable_objects = serializers.deserialize('json', selectable_objects)
+            selectable_objects = json.loads(selectable_objects)
+            object_ids = []
+            for obj in selectable_objects:
+                object_ids.append(obj["pk"])
+            selectable_objects = object_type.objects.filter(pk__in=object_ids)
         return ModelChoiceField(selectable_objects, **init_data)
 
     def serialize(self, required=False, label="", initial=None, help_text="", **kwargs):

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -32,7 +32,7 @@ class CustomDataField(models.Model):
         ("reference", "Object name linked to the object")
     )
     widgets = {
-        "rfid": RFIDWidget,
+        "rfid": TextInput,
         "text": Textarea,
         "string": TextInput,
         "boolean": CheckboxInput,

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -59,12 +59,12 @@ class CustomDataField(models.Model):
         name = self.name
         return name.replace('_', ' ').title()
 
-    def serialize_rfid(self, rfid):
+    def serialize_rfid(self, rfid, **kwargs):
         return {
             "initial": rfid,
         }
 
-    def serialize_text(self, text, max_length=300, min_length=0, strip=True):
+    def serialize_text(self, text, max_length=300, min_length=0, strip=True, **kwargs):
         return {
             "initial": text,
             "max_length": max_length,
@@ -72,7 +72,7 @@ class CustomDataField(models.Model):
             "strip": strip
         }
 
-    def serialize_string(self, string, max_length=50, min_length=0, strip=True):
+    def serialize_string(self, string, max_length=50, min_length=0, strip=True, **kwargs):
         return {
             "initial": string,
             "max_length": max_length,
@@ -80,32 +80,32 @@ class CustomDataField(models.Model):
             "strip": strip
         }
 
-    def serialize_boolean(self, boolean):
+    def serialize_boolean(self, boolean, **kwargs):
         return {
             "initial": boolean,
         }
 
-    def serialize_int(self, value, min_value=-100, max_value=100):
+    def serialize_int(self, value, min_value=-100, max_value=100, **kwargs):
         return {
             "initial": value,
             "min_value": min_value,
             "max_value": max_value
         }
 
-    def serialize_float(self, value, min_value=-1000, max_value=1000):
+    def serialize_float(self, value, min_value=-1000, max_value=1000, **kwargs):
         return {
             "initial": value,
             "min_value": min_value,
             "max_value": max_value
         }
 
-    def serialize_choice(self, value, choices=(("None", "No choices provided"),)):
+    def serialize_choice(self, value, choices=(("None", "No choices provided"),), **kwargs):
         return {
             "initial": value,
             "choices": choices
         }
 
-    def serialize_reference(self, obj, object_type=None, selectable_objects=None):
+    def serialize_reference(self, obj, object_type=None, selectable_objects=None, **kwargs):
         if object_type is None:
             raise ValueError("Object Type must be specified when serializing an object reference")
         if not selectable_objects:

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -55,6 +55,10 @@ class CustomDataField(models.Model):
     name = models.CharField(max_length=30)
     data_type = models.CharField(max_length=20, choices=data_types)
 
+    def __str__(self):
+        name = self.name
+        return name.replace('_', ' ').title()
+
     def serialize_rfid(self, rfid):
         return {
             "initial": rfid,
@@ -163,7 +167,7 @@ class CustomDataField(models.Model):
 
 class GearType(models.Model):
 
-    name = models.CharField(max_length="30")
+    name = models.CharField(max_length=30)
 
     #: The department to which this type of gear belongs (roughly corresponds to STL positions)
     department = models.ForeignKey(Department, on_delete=models.CASCADE)
@@ -172,7 +176,7 @@ class GearType(models.Model):
     data_fields = models.ManyToManyField(CustomDataField)
 
     def __str__(self):
-        return self
+        return self.name
 
 
 class GearManager(models.Manager):

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -194,9 +194,11 @@ class GearManager(models.Manager):
         name += ", ".join(attributes)
         return name
 
-    def create(self, rfid, gear_type, name=None, **gear_data):
+    def _create(self, rfid, gear_type, name=None, **gear_data):
         """
         Create a piece of gear that contains the basic data, and all additional data specified by the gear_type
+
+        NOTE: THIS SHOULD ALWAYS BE CALLED THROUGH A TRANSACTION!
         """
 
         if not name:
@@ -222,8 +224,13 @@ class GearManager(models.Manager):
 
         return gear
 
-    def add(self, rfid, name, gear_type, **gear_data):
-        """Alias for gear creation"""
+    def _add(self, rfid, name, gear_type, **gear_data):
+        """
+        Alias for gear creation
+
+
+        NOTE: THIS SHOULD ALWAYS BE CALLED THROUGH A TRANSACTION!
+        """
         return self.create(rfid, gear_type, name=name, **gear_data)
 
 

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -191,10 +191,12 @@ class GearManager(models.Manager):
 
         name = f"{gear_type.name} - "
         # Get all custom data fields for this data_type, except those that contain a reference
-        attr_fields = CustomDataField.objects.filter(gear_type=gear_type).exclude(data_type='reference')
+        attr_fields = CustomDataField.objects.filter(geartype=gear_type).exclude(data_type='reference')
         attributes = []
         for field in attr_fields:
-            attributes.append(gear_data[field.name])
+            value = gear_data[field.name]['initial']
+            if value:
+                attributes.append(value)
         name += ", ".join(attributes)
         return name
 
@@ -213,11 +215,11 @@ class GearManager(models.Manager):
             rfid=rfid,
             name=name,
             status=0,
-            gear_type=gear_type
+            geartype=gear_type
         )
 
         # Filter out any passed data that is not referenced by the gear type
-        extra_fields = CustomDataField.objects.filter(gear_type=gear_type)
+        extra_fields = CustomDataField.objects.filter(geartype=gear_type)
         data_dict = {
             field.name: field.serialize(gear_data[field.name]) for field in extra_fields
         }
@@ -243,7 +245,7 @@ class Gear(models.Model):
     The base model for a piece of gear
     """
 
-    objects = GearManager
+    objects = GearManager()
 
     class Meta:
         verbose_name_plural = "Gear"
@@ -270,7 +272,7 @@ class Gear(models.Model):
     #: The date at which this gear is due to be returned, null if not checked out
     due_date = models.DateField(null=True, default=None)
 
-    gear_type = models.ForeignKey(GearType, on_delete=models.CASCADE)
+    geartype = models.ForeignKey(GearType, on_delete=models.CASCADE)
 
     gear_data = models.CharField(max_length=2000)
 

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -48,6 +48,15 @@ class CustomDataField(models.Model):
     label = models.CharField(max_length=30, default="")
     help_text = models.CharField(max_length=200, default="")
 
+    choices = models.TextField(
+        max_length=1000,
+        default='None; No choices provided\nNope; Also not a choice',
+        help_text="Must use this format to define choices!\n"
+                  "Each choice must be on it's own line, and consist of a short name (used internally), and a "
+                  "description (seen by the user). Name description pairs must be separated by a semicolon, and no "
+                  "semicolons are allowed in either the name or the description"
+    )
+
     def __str__(self):
         name = self.name
         return name.replace('_', ' ').title()
@@ -93,10 +102,18 @@ class CustomDataField(models.Model):
             "max_value": max_value
         }
 
-    def serialize_choice(self, value, choices=(("None", "No choices provided"),), **kwargs):
+    def serialize_choice(self, value, choices=None, **kwargs):
+        # If a set of choices is not given, then try to parse out the choices from the choice field
+        if not choices:
+            choices = []
+            choice_list = self.choices.split("\n")
+            for choice_pair in choice_list:
+                choice = choice_pair.split(";")
+                choices.append((choice[0].strip(), choice[1].strip()))
+
         return {
             "initial": value,
-            "choices": choices
+            "choices": tuple(choices)
         }
 
     def serialize(self, required=None, label=None, initial=None, help_text=None, **kwargs):

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -292,6 +292,10 @@ class Gear(models.Model):
     def __str__(self):
         return self.name
 
+    def get_department(self):
+        return self.geartype.department
+    get_department.short_description = "Department"
+
     def is_available(self):
         """Returns True if the gear is available for renting"""
         if self.status == 0:

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -110,13 +110,13 @@ class CustomDataField(models.Model):
             kwargs['app_label'] = object_type._meta.app_label
             kwargs['model_name'] = object_type.__name__
         elif 'app_label' in kwargs and 'model_name' in kwargs:
-            object_type = importlib.import_module(f"{kwargs['app_label']}.models.{kwargs['model_name']}")
+            object_type = importlib.__import__(f"{kwargs['app_label']}.models", fromlist=(kwargs['model_name'],))
 
         if not selectable_objects:
             selectable_objects = object_type.objects.all()
 
         return {
-            "initial": str(obj),
+            "initial": str(obj) if obj else None,
             "pk": obj.pk if obj else None,
             "app_label": object_type._meta.app_label,
             "model_name": object_type.__name__,

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -8,13 +8,17 @@ from .CertificationModels import Certification
 from django.forms.widgets import TextInput, Textarea, NumberInput, CheckboxInput, Select
 from core.forms.widgets import RFIDWidget
 
+from django.forms.fields import CharField, ChoiceField, IntegerField, FloatField, BooleanField
+from django.forms.models import ModelChoiceField
+from core.forms.fields.RFIDField import RFIDField
+
 from django.core import serializers
 
 # TODO: subclass Gear for all the different types of gear
 # TODO: figure out how to "subclass" via the django admin, so a new type of gear could be added if necessary
 
 
-class CustomDataField:
+class CustomDataField(models.Model):
     data_types = (
         ("rfid", "10 digit RFID"),
         ("text", "String of any length"),
@@ -35,18 +39,28 @@ class CustomDataField:
         "choice": Select,
         "reference": Select
     }
+    fields = {
+        "rfid": RFIDField,
+        "text": CharField,
+        "string": CharField,
+        "boolean": BooleanField,
+        "int": IntegerField,
+        "float": FloatField,
+        "choice": ChoiceField,
+        "reference": ModelChoiceField
+    }
 
     name = models.CharField(max_length=30)
     data_type = models.CharField(max_length=20, choices=data_types)
 
-    def serialize_rfid(self, rfid, ):
+    def serialize_rfid(self, rfid):
         return {
-            "value": rfid,
+            "initial": rfid,
         }
 
     def serialize_text(self, text, max_length=300, min_length=0, strip=True):
         return {
-            "value": text,
+            "initial": text,
             "max_length": max_length,
             "min_length": min_length,
             "strip": strip
@@ -54,7 +68,7 @@ class CustomDataField:
 
     def serialize_string(self, string, max_length=50, min_length=0, strip=True):
         return {
-            "value": string,
+            "initial": string,
             "max_length": max_length,
             "min_length": min_length,
             "strip": strip
@@ -62,72 +76,85 @@ class CustomDataField:
 
     def serialize_boolean(self, boolean):
         return {
-            "value": boolean,
+            "initial": boolean,
         }
 
     def serialize_int(self, value, min_value=-100, max_value=100):
         return {
-            "value": value,
+            "initial": value,
             "min_value": min_value,
             "max_value": max_value
         }
 
     def serialize_float(self, value, min_value=-1000, max_value=1000):
         return {
-            "value": value,
+            "initial": value,
             "min_value": min_value,
             "max_value": max_value
         }
 
     def serialize_choice(self, value, choices=(("None", "No choices provided"),)):
-        choice_dict = {}
-        for choice in choices:
-            choice_dict[choice[0]] = choice[1]
         return {
-            "value": value,
-            "choices": choice_dict
+            "initial": value,
+            "choices": choices
         }
 
     def serialize_reference(self, obj, object_type=None, selectable_objects=None):
         if object_type is None:
             raise ValueError("Object Type must be specified when serializing an object reference")
-        if selectable_objects:
+        if not selectable_objects:
             selectable_objects = object_type.objects.all()
         return {
-            "value": obj.name,
+            "initial": obj.name,
             "pk": obj.pk,
             "object_type": str(object_type),
             "selectable_objects": serializers.serialize("json", selectable_objects)
         }
+    
+    def get_reference_field(self, initial=None, pk=None, object_type=None, selectable_objects=None, **init_data):
+        pass
 
-    def serialize(self, data, required=False, label="", initial=None, help_text="", **kwargs):
+    def serialize(self, required=False, label="", initial=None, help_text="", **kwargs):
         """Execute the serialize function appropriate for the current data type"""
         serialize_function = getattr(self, f"serialize_{self.data_type}")
-        serialized = serialize_function(data, **kwargs)
+        serialized = serialize_function(initial, **kwargs)
         serialized["data_type"] = self.data_type
         serialized["name"] = self.name
         serialized["required"] = required
         serialized["label"] = label
-        serialized["initial"] = initial
         serialized["help_text"] = help_text
+        return serialized
 
     def get_value(self, data_dict):
         """Returns the object currently stored by this field"""
         if self.data_type == "choice":
-            selected = data_dict["value"]
+            selected = data_dict["initial"]
             return data_dict["choices"][selected]
         elif self.data_type == "reference":
             obj_type = data_dict["object_type"]
             model = importlib.import_module(f"core.models.{obj_type}")
             return model.objects.get(pk=data_dict["pk"])
         else:
-            return data_dict["value"]
+            return data_dict["initial"]
 
-    def get_field(self, json_data):
+    def get_field(self, init_data, current=None):
         """Returns the appropriate FormField for the current data type"""
+        # If a current field value is passed, set it as the initial value for the returned form field
+        if current is not None:
+            init_data['initial'] = current
+
+        init_data['widget'] = self.widgets[self.data_type]
+
+        # Only reference fields need special attention
+        if self.data_type == 'reference':
+            field = self.get_reference_field(**init_data)
+        else:
+            field = self.fields[self.data_type](**init_data)
+
+        return field
 
 
-class GearType:
+class GearType(models.Model):
     #: The department to which this type of gear belongs (roughly corresponds to STL positions)
     department = models.ForeignKey(Department, on_delete=models.CASCADE)
 

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -84,6 +84,8 @@ class CustomDataField(models.Model):
     def serialize_boolean(self, boolean, **kwargs):
         return {
             "initial": boolean,
+            "blank": True,
+            "null": True
         }
 
     def serialize_int(self, value, min_value=-100, max_value=100, **kwargs):
@@ -171,12 +173,18 @@ class CustomDataField(models.Model):
         else:
             return None
 
-    def get_field(self, data_type=None, current=None, **init_data):
+    def get_field(self, current=None, **init_data):
         """Returns the appropriate FormField for the current data type"""
+
         # If a current field value is passed, set it as the initial value for the returned form field
         if current is not None:
             init_data['initial'] = current
 
+        # Remove data that is used for reference in JSON format, but would interfere with form field instantiation
+        init_data.pop('name')
+        init_data.pop('data_type')
+
+        # Make sure that the default widget for this data type is used
         init_data['widget'] = self.widgets[self.data_type]
 
         # Only reference fields need special attention

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -171,7 +171,7 @@ class CustomDataField(models.Model):
         else:
             return None
 
-    def get_field(self, init_data, current=None):
+    def get_field(self, data_type=None, current=None, **init_data):
         """Returns the appropriate FormField for the current data type"""
         # If a current field value is passed, set it as the initial value for the returned form field
         if current is not None:
@@ -200,6 +200,13 @@ class GearType(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_field_names(self):
+        """Return a list of the names of fields included in this gear type"""
+        field_names = []
+        for field in self.data_fields.all():
+            field_names.append(field.name)
+        return field_names
 
 
 class GearManager(models.Manager):
@@ -294,7 +301,17 @@ class Gear(models.Model):
             field = gear_type.data_fields.get(name=item)
             return field.get_value(gear_data[item])
         else:
-            raise AttributeError(f'No field {item} for {repr(self)}!')
+            raise AttributeError(f'No attribute {item} for {repr(self)}!')
+
+    def get_extra_fieldset(self, name="Additional Data", classes=('wide',)):
+        """Get a fieldset that contains data on how to represent the extra data fields contained in geartype"""
+        fieldset = (
+            name, {
+                'classes': classes,
+                'fields': self.geartype.get_field_names()
+            }
+        )
+        return fieldset
 
     @property
     def name(self):

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -195,7 +195,6 @@ class GearManager(models.Manager):
         Name will be in the form: <GearType> - <attr 1>, <attr 2>, etc...
         """
 
-        name = f"{gear_type.name} - "
         # Get all custom data fields for this data_type, except those that contain a reference
         attr_fields = CustomDataField.objects.filter(geartype=gear_type).exclude(data_type='reference')
         attributes = []
@@ -203,7 +202,13 @@ class GearManager(models.Manager):
             value = gear_data[field.name]['initial']
             if value:
                 attributes.append(value)
-        name += ", ".join(attributes)
+
+        if attributes:
+            attr_string = ", ".join(attributes)
+            name = f'{gear_type.name} - {attr_string}'
+        else:
+            name = gear_type.name
+
         return name
 
     def _create(self, rfid, gear_type, name=None, **gear_data):

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 
 from django.db import models
 from .MemberModels import Member
@@ -161,17 +162,77 @@ class CustomDataField(models.Model):
 
 
 class GearType(models.Model):
+
+    name = models.CharField(max_length="30")
+
     #: The department to which this type of gear belongs (roughly corresponds to STL positions)
     department = models.ForeignKey(Department, on_delete=models.CASCADE)
 
     #:
     data_fields = models.ManyToManyField(CustomDataField)
 
+    def __str__(self):
+        return self
+
+
+class GearManager(models.Manager):
+
+    @staticmethod
+    def generate_name(gear_type, **gear_data):
+        """
+        Auto-generate a name that can (semi-uniquely) identify this piece of gear
+
+        Name will be in the form: <GearType> - <attr 1>, <attr 2>, etc...
+        """
+
+        name = f"{gear_type.name} - "
+        # Get all custom data fields for this data_type, except those that contain a reference
+        attr_fields = CustomDataField.objects.filter(gear_type=gear_type).exclude(data_type='reference')
+        attributes = []
+        for field in attr_fields:
+            attributes.append(gear_data[field.name])
+        name += ", ".join(attributes)
+        return name
+
+    def create(self, rfid, gear_type, name=None, **gear_data):
+        """
+        Create a piece of gear that contains the basic data, and all additional data specified by the gear_type
+        """
+
+        if not name:
+            name = self.generate_name(gear_type, **gear_data)
+
+        # Create a simple piece of gear without any extra gear data
+        gear = Gear(
+            rfid=rfid,
+            name=name,
+            status=0,
+            gear_type=gear_type
+        )
+
+        # Filter out any passed data that is not referenced by the gear type
+        extra_fields = CustomDataField.objects.filter(gear_type=gear_type)
+        data_dict = {
+            field.name: field.serialize(gear_data[field.name]) for field in extra_fields
+        }
+
+        # Add in the additional data as a string before saving the piece of gear
+        gear.gear_data = json.dumps(data_dict)
+        gear.save()
+
+        return gear
+
+    def add(self, rfid, name, gear_type, **gear_data):
+        """Alias for gear creation"""
+        return self.create(rfid, gear_type, name=name, **gear_data)
+
 
 class Gear(models.Model):
     """
     The base model for a piece of gear
     """
+
+    objects = GearManager
 
     class Meta:
         verbose_name_plural = "Gear"
@@ -189,9 +250,6 @@ class Gear(models.Model):
     #: The status determines what transactions the gear can participate in and where it is visible
     status = models.IntegerField(choices=status_choices)
 
-    #: The department to which this gear belongs (roughly corresponds to STL positions)
-    department = models.ForeignKey(Department, on_delete=models.CASCADE)
-
     #: All the certifications that a member must posses to be allowed to check out this gear
     min_required_certs = models.ManyToManyField(Certification, verbose_name="Minimal Certifications Required for Rental")
 
@@ -202,6 +260,8 @@ class Gear(models.Model):
     due_date = models.DateField(null=True, default=None)
 
     gear_type = models.ForeignKey(GearType, on_delete=models.CASCADE)
+
+    gear_data = models.CharField(max_length=2000)
 
     # TODO: Add image of gear
 

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -87,7 +87,6 @@ class CustomDataField(models.Model):
     def serialize_boolean(self, boolean, **kwargs):
         return {
             "initial": boolean,
-            "blank": True,
             "null": True
         }
 

--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -273,10 +273,10 @@ class Gear(models.Model):
     min_required_certs = models.ManyToManyField(Certification, verbose_name="Minimal Certifications Required for Rental")
 
     #: Who currently has this piece of gear. If null, then the gear is not checked out
-    checked_out_to = models.ForeignKey(Member, null=True, on_delete=models.SET_NULL)
+    checked_out_to = models.ForeignKey(Member, blank=True, null=True, on_delete=models.SET_NULL)
 
     #: The date at which this gear is due to be returned, null if not checked out
-    due_date = models.DateField(null=True, default=None)
+    due_date = models.DateField(blank=True, null=True, default=None)
 
     geartype = models.ForeignKey(GearType, on_delete=models.CASCADE)
 

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -116,7 +116,7 @@ class TransactionManager(models.Manager):
         gear.due_date = return_date
         gear.save()
 
-        return transaction
+        return transaction, gear
 
     def add_gear(self, authorizer_rfid, gear_rfid, gear_type, *required_certs, is_new=True, **init_data):
         """
@@ -183,7 +183,7 @@ class TransactionManager(models.Manager):
         gear.due_date = None
         gear.save()
 
-        return transaction
+        return transaction, gear
 
     def retag_gear(self, authorizer_rfid, old_rfid, new_rfid):
         """
@@ -208,7 +208,7 @@ class TransactionManager(models.Manager):
         gear.rfid = new_rfid
         gear.save()
 
-        return transaction
+        return transaction, gear
 
     def fix_gear(self, authorizer_rfid, gear_rfid, repairs_description, person_repairing):
         """
@@ -232,7 +232,7 @@ class TransactionManager(models.Manager):
 
         gear.set_status = 0
         gear.save()
-        return transaction
+        return transaction, gear
 
     def break_gear(self, authorizer_rfid, gear_rfid, damage_description):
         """
@@ -255,7 +255,7 @@ class TransactionManager(models.Manager):
         gear.set_status = 2
         gear.save()
 
-        return transaction
+        return transaction, gear
 
     def missing_gear(self, authorizer_rfid, gear_rfid):
         """
@@ -277,7 +277,7 @@ class TransactionManager(models.Manager):
 
         gear.set_status = 3
         gear.save()
-        return transaction
+        return transaction, gear
 
     def expire_gear(self, authorizer_rfid, gear_rfid):
         """
@@ -300,7 +300,7 @@ class TransactionManager(models.Manager):
 
         gear.set_status = 4
         gear.save()
-        return transaction
+        return transaction, gear
 
     def delete_gear(self, authorizer_rfid, gear_rfid, reason):
         """
@@ -324,7 +324,7 @@ class TransactionManager(models.Manager):
         gear.checked_out_to = None
         gear.department.notify_gear_removed()
 
-        return transaction
+        return transaction, gear
 
     def override(self, authorizer_rfid, gear_rfid, **kwargs):
         """
@@ -359,7 +359,7 @@ class TransactionManager(models.Manager):
 
         # Save the changes made in a transaction
         transaction = self.__make_transaction(authorizer_rfid, "Delete", gear, comments=action)
-        return transaction
+        return transaction, gear
 
 
 class Transaction(models.Model):

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -118,7 +118,7 @@ class TransactionManager(models.Manager):
 
         return transaction
 
-    def add_gear(self, authorizer_rfid, gear_rfid, gear_name, gear_department, *required_certs, is_new=True):
+    def add_gear(self, authorizer_rfid, gear_rfid, gear_type, *required_certs, is_new=True, **init_data):
         """
         Create a new piece of gear and create a transaction logging the addition.
 
@@ -127,21 +127,20 @@ class TransactionManager(models.Manager):
 
         :param authorizer_rfid: string, the 10-digit rfid of entity authorizing the transaction (should be staffer)\
         :param gear_rfid: string, the 10-digit rfid of the gear being added
-        :param gear_name: string, the name of the piece of gear to be checked out
-        :param gear_department: the department this gear belongs in
+        :param gear_type: the type of gear that this is
         :param required_certs: a list of the minimum certifications required to check this piece of gear out
         :param is_new: bool, notes whether this piece of gear was just acquired by the club. If the piece of gear is not
             newly acquired by the club, then it might be a piece of gear that lost it's tag!
+        :param init_data: any additional data about the gear
+
         :return: Transaction (the transaction logging this gear addition), gear (the new piece of gear)
         """
         # First must make sure that the rfid is not in use by anything
         validate_rfid(gear_rfid)
 
         # Create the gear, because it is needed for creating the transaction
-        gear = Gear(rfid=gear_rfid, name=gear_name, department=gear_department, status=0)
-        gear.save()
-        for cert in required_certs:
-            gear.min_required_certs.add(cert)
+        gear = Gear.objects.create(gear_rfid, gear_type, **init_data)
+        gear.min_required_certs.add(required_certs)
         gear.save()
         if is_new:
             comment = "Newly Acquired"

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -139,7 +139,7 @@ class TransactionManager(models.Manager):
         validate_rfid(gear_rfid)
 
         # Create the gear, because it is needed for creating the transaction
-        gear = Gear.objects.create(gear_rfid, gear_type, **init_data)
+        gear = Gear.objects._create(gear_rfid, gear_type, **init_data)
         gear.min_required_certs.add(required_certs)
         gear.save()
         if is_new:

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -348,7 +348,7 @@ class TransactionManager(models.Manager):
             raise ValidationError("You can't do admin overrides unless you know the admin code")
 
         # All the changes made will be described here
-        action = "Admin override on {} [{}]: \n".format(gear, gear_rfid)
+        action = f"Admin override on {gear} [{gear_rfid}]: \n"
 
         # Remove the fields that were appended from the geartype, they will be saved in gear_data
         for field_name in gear.geartype.get_field_names():
@@ -357,13 +357,15 @@ class TransactionManager(models.Manager):
         # Set each of the available kwargs to their desired value if they are not none
         for kwarg in kwargs.keys():
 
-            value = kwargs[kwarg]
+            new_value = kwargs[kwarg]
             old_value = gear.__getattribute__(kwarg)
-            gear.__setattr__(kwarg, value)
-            action += "  Changed {} from {} to {}\n".format(kwarg, old_value, value)
+
+            if new_value != old_value:
+                gear.__setattr__(kwarg, new_value)
+                action += f"  Changed {kwarg} from {old_value} to {new_value};"
 
         # Save the changes made in a transaction
-        transaction = self.__make_transaction(authorizer_rfid, "Delete", gear, comments=action)
+        transaction = self.__make_transaction(authorizer_rfid, "Override", gear, comments=action)
         return transaction, gear
 
 
@@ -393,7 +395,7 @@ class Transaction(models.Model):
             ("ReTag",    "Change Tag"),
             ("Break",    "Set Broken"),
             ("Fix",      "Set Fixed"),
-            ("Override", "Admin Override")
+            ("Override", "Admin Change")
         )
          ),
         ("Auto Updates", (

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -344,8 +344,9 @@ class TransactionManager(models.Manager):
         """
         gear = Gear.objects.get(rfid=gear_rfid)
 
-        if authorizer_rfid != "0000000000":
-            raise ValidationError("You can't do admin overrides unless you know the admin code")
+        member = Member.objects.get(authorizer_rfid)
+        if not member.has_permission('change_gear'):
+            raise ValidationError("You don't have the permission to change gear!")
 
         # All the changes made will be described here
         action = f"Admin override on {gear} [{gear_rfid}]: \n"

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -350,8 +350,13 @@ class TransactionManager(models.Manager):
         # All the changes made will be described here
         action = "Admin override on {} [{}]: \n".format(gear, gear_rfid)
 
+        # Remove the fields that were appended from the geartype, they will be saved in gear_data
+        for field_name in gear.geartype.get_field_names():
+            kwargs.pop(field_name)
+
         # Set each of the available kwargs to their desired value if they are not none
         for kwarg in kwargs.keys():
+
             value = kwargs[kwarg]
             old_value = gear.__getattribute__(kwarg)
             gear.__setattr__(kwarg, value)

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -140,7 +140,8 @@ class TransactionManager(models.Manager):
 
         # Create the gear, because it is needed for creating the transaction
         gear = Gear.objects._create(gear_rfid, gear_type, **init_data)
-        gear.min_required_certs.add(required_certs)
+        if required_certs:
+            gear.min_required_certs.add(required_certs)
         gear.save()
         if is_new:
             comment = "Newly Acquired"

--- a/core/templates/admin/core/gear/submit_line.html
+++ b/core/templates/admin/core/gear/submit_line.html
@@ -1,0 +1,6 @@
+{% load i18n admin_urls %}
+<div class="submit-row">
+{% block submit-row %}
+{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save">{% endif %}
+{% endblock %}
+</div>

--- a/core/views/GearViews.py
+++ b/core/views/GearViews.py
@@ -2,9 +2,13 @@ from django.views.generic.detail import DetailView
 
 from django.utils import timezone
 
-from core.models.GearModels import Gear
+from core.models.GearModels import Gear, GearType
 from core.views.ViewList import RestrictedViewList
 from core.views.common import ModelDetailView
+
+
+class GearTypeDetailView(ModelDetailView):
+    model = GearType
 
 
 class GearDetailView(ModelDetailView):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-django==2.0.7
-django-phonenumber-field==2.0.0
+django==2.1.1
+django-phonenumber-field==2.0.1
 names==0.3.0
 progressbar2==3.34.3
 pillow==5.2.0


### PR DESCRIPTION
Added dynamic Gear types.

With gear types, every piece of gear has a geartype attached to it. This gear type (i.e. Backpack, Skis, Rope etc) determines what department this piece of gear belongs in, and the 'additional data' attached to the piece of gear.

### Gear Types and Custom Data fields
The gear model now contains two additional Model Fields: 'geartype' (a Foreign Key) and 'gear_data' (a long Char Field). Each piece of gear must have a Gear Type attached. This gear type then can have any number 'CustomDataField's attached. These custom data fields define how the data related to the gear is serialized to JSON, converted to a python value, and converted to a form field for display in the Excursion Admin. 

When a piece of gear is saved to the database, the associated geartype calls on each of the CustomDataFields associated with it, each of which knows how to serialize itself to JSON. The model then stores the compiled JSON (keyed by field name) in gear_data. When an object is pulled from the database, the geartype defines which CustomDataFields should be used when reconstructing the object.

Both CustomDataFields and GearTypes can be created in the django admin (if users have at least board permission level). They can, however, not be edited, as editing either if it is attached to a piece of gear would mean that data can no longer be recovered from the JSON format.

CustomDataField data types cannot be added through the admin page. Currently, the available types are :
```
    ("rfid", "10 digit RFID"),
    ("text", "String of any length"),
    ("string", "Short string of up to 50 characters"),
    ("boolean", "True/False value"),
    ("int", "Integer value"),
    ("float", "Float value"),
    ("choice", "Short string selectable from a list"),
```

### Adding Gear
When adding gear, only the universal fields are shown. Once a user clicks 'Save' the basic gear data is saved, and the user is redirected to the 'change' page for that piece of gear

### Changing Gear
On the change gear page, all the basic data for the piece of gear is accessible and can be edited. The only exception to this is the GearType, which cannot be edited, for fear of losing data. 

In addition to the basic data, this page also generated Form Fields for each of the CustomDataFields defined in GearData. Each of these fields knows how to convert itself into a FormField, and carry out validations necessary for the given data type.  

### TL;DR
Different data can be stored for each GearType in JSON format using CustomDataFields
