### PR TITLE
Fix member permissions

### DIFF
--- a/buildPermissions.py
+++ b/buildPermissions.py
@@ -26,6 +26,7 @@ group_type = ContentType.objects.get_for_model(Group)
 question_type = ContentType.objects.get_for_model(Question)
 answer_type = ContentType.objects.get_for_model(Answer)
 
+
 def build_all():
     """Build all the groups. Must be done in ascending order of power"""
     build_just_joined()

--- a/buildPermissions.py
+++ b/buildPermissions.py
@@ -67,6 +67,10 @@ def build_member():
         name="Allowed to rent gear",
         content_type=gear_type)
     add_permission(
+        codename="view_gear",
+        name="Has access to at least one item on the gear list",
+        content_type=gear_type)
+    add_permission(
         codename="view_department",
         name="Can see department information",
         content_type=department_type)
@@ -74,10 +78,6 @@ def build_member():
         codename="view_certification",
         name="Can see certification information",
         content_type=certification_type)
-    add_permission(
-        codename="view_gear",
-        name="Can see and search the gear list",
-        content_type=gear_type)
     add_permission(
         codename='view_transaction',
         name="Can view transactions",
@@ -97,6 +97,10 @@ def build_staffer():
     add_permission(
         codename="change_gear",
         name="Can change the info on gear",
+        content_type=gear_type)
+    add_permission(
+        codename="view_general_gear",
+        name="Can see and search the gear list",
         content_type=gear_type)
     add_permission(
         codename="authorize_transactions",

--- a/core/admin/ViewableAdmin.py
+++ b/core/admin/ViewableAdmin.py
@@ -22,6 +22,8 @@ class ViewableModelAdmin(ModelAdmin):
     list_view = RestrictedViewList
     detail_view_class = ModelDetailView
 
+    show_full_result_count = False
+
     def get_detail_view(self):
         """Get the detail view as a view (function) wrapped to automatically check permissions"""
 

--- a/core/admin/ViewableAdmin.py
+++ b/core/admin/ViewableAdmin.py
@@ -36,7 +36,7 @@ class ViewableModelAdmin(ModelAdmin):
         detail_view = detail.as_view()
         return wrap(detail_view)
 
-    def has_view_permission(self, request):
+    def has_view_permission(self, request, obj=None):
         opts = self.opts
         codename = get_permission_codename('view', opts)
         return request.user.has_perm(f'{opts.app_label}.{codename}')

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -169,7 +169,7 @@ class MemberFinishForm(forms.ModelForm):
         member.last_name = self.cleaned_data['last_name']
         member.phone_number = self.cleaned_data['phone_number']
         member.picture = self.cleaned_data['picture']
-        member.status = 2
+        member = member.promote_to_active()
 
         member.save()
         return member

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -175,6 +175,11 @@ class Member(AbstractBaseUser):
         """Expires this member's membership"""
         self.group = Group.objects.get(name="Expired")
 
+    def promote_to_active(self):
+        """Move the member to the group of active members"""
+        self.group = Group.objects.get(name="Member")
+        return self
+
     def send_email(self, title, body, from_email='system@excursionclubucsb.org'):
         """Sends an email to the member"""
         send_mail(title, body, from_email, [self.email], fail_silently=False)

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -115,16 +115,17 @@ class Member(AbstractBaseUser):
     @property
     def is_staff(self):
         """
-        Property that is used by django to determine whether a user is allowed to log in to the admin
+        Property that is used by django to determine whether a user is allowed to log in to the admin: i.e. everyone
         """
-        return self.group.name == "Member" \
-            or self.group.name == "Staff" \
-            or self.group.name == "Board" \
-            or self.group.name == "Admin"
+        return True
 
     @property
     def is_staffer(self):
-        """Returns true if this member has staffer privileges"""
+        """
+        Returns true if this member has staffer privileges
+
+        NOTE: Avoid using this function, it's much better to explicitly check for permissions
+        """
         return self.group.name == "Staff" \
             or self.group.name == "Board" \
             or self.group.name == "Admin"

--- a/core/views/GearViews.py
+++ b/core/views/GearViews.py
@@ -27,4 +27,4 @@ class GearViewList(RestrictedViewList):
         if self.request.user.is_staffer:
             self.restriction_filters["status__lte"] = 3
         else:
-            self.restriction_filters["status"] = 0
+            self.restriction_filters["checked_out_to_id__exact"] = self.request.user.id

--- a/core/views/GearViews.py
+++ b/core/views/GearViews.py
@@ -14,9 +14,16 @@ class GearDetailView(ModelDetailView):
 
 class GearViewList(RestrictedViewList):
 
+    def __init__(self, *args, **kwargs):
+        super(GearViewList, self).__init__(*args, **kwargs)
+
+        # If the person won't have the right to view gear generally, they will only see the gear checked out to them
+        if not self.request.user.has_permission('view_general_gear'):
+            self.title = 'Gear checked out to you'
+
     def test_func(self):
-        """Users can see the gear list if the have that permission"""
-        return self.request.user.has_permission("view_gear")
+        """Everyone can see the gear list, but for non-staffers it is the gear checked out to them"""
+        return self.request.user.has_permission('view_gear')
 
     def can_view_all(self):
         """If a user isn't allowed to view all gear, only show the gear that is available"""
@@ -24,7 +31,7 @@ class GearViewList(RestrictedViewList):
 
     def set_restriction_filters(self):
         """Staffers should be able to see active gear, members should only see available gear"""
-        if self.request.user.is_staffer:
+        if self.request.user.has_permission('view_general_gear'):
             self.restriction_filters["status__lte"] = 3
         else:
             self.restriction_filters["checked_out_to_id__exact"] = self.request.user.id

--- a/core/views/MemberViews.py
+++ b/core/views/MemberViews.py
@@ -1,6 +1,7 @@
 from django.views.generic.edit import UpdateView
 from django.urls import reverse
 from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.auth.models import Group
 
 from ExCSystem.settings.base import WEB_BASE
 
@@ -61,6 +62,13 @@ class MemberFinishView(UserPassesTestMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context = get_default_context(self, context)
         return context
+
+    def form_valid(self, form):
+        """Called when the finish form is filled out correctly, so make the member active before continuing"""
+        member = self.get_object()
+        member.group = Group.objects.get(name="Member")
+        member.save()
+        return super(MemberFinishView, self).form_valid(form)
 
     def get_success_url(self):
         return WEB_BASE + reverse("admin:core_member_detail", kwargs={'pk': self.object.pk})

--- a/core/views/MemberViews.py
+++ b/core/views/MemberViews.py
@@ -1,7 +1,6 @@
 from django.views.generic.edit import UpdateView
 from django.urls import reverse
 from django.contrib.auth.mixins import UserPassesTestMixin
-from django.contrib.auth.models import Group
 
 from ExCSystem.settings.base import WEB_BASE
 
@@ -62,13 +61,6 @@ class MemberFinishView(UserPassesTestMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         context = get_default_context(self, context)
         return context
-
-    def form_valid(self, form):
-        """Called when the finish form is filled out correctly, so make the member active before continuing"""
-        member = self.get_object()
-        member.group = Group.objects.get(name="Member")
-        member.save()
-        return super(MemberFinishView, self).form_valid(form)
 
     def get_success_url(self):
         return WEB_BASE + reverse("admin:core_member_detail", kwargs={'pk': self.object.pk})

--- a/core/views/ViewList.py
+++ b/core/views/ViewList.py
@@ -55,6 +55,8 @@ class RestrictedViewList(UserPassesTestMixin, ViewList):
 
     def get_queryset(self, request):
 
+        # Reset restriction filters, since otherwise they'll be shared between view_lists
+        self.restriction_filters = {}
         queryset = super(RestrictedViewList, self).get_queryset(request)
 
         # If the user is not allowed to view all the items, additionally filter the gotten queryset before returning it

--- a/temp_tesp.py
+++ b/temp_tesp.py
@@ -1,0 +1,14 @@
+class Test(object):
+
+    def test_func(self, data):
+        print("In the test func")
+        print(f"got data={data}")
+        print()
+
+    def run(self):
+        func = getattr(self, "test_func")
+        func("test")
+
+
+test = Test()
+test.run()


### PR DESCRIPTION
Made a bunch of small fixes related to member permissions and how the admin site changes depending on the permissions of the user

Members could see total number of gear (removed)
  - 'Just Joined' and 'Expired' cannot see any data about gear 
  - 'Members' now only see the gear checked out to them
  - 'Staffer' Still see all gear that is not dormant or removed
  - 'Board' still see all gear of any status


