### PR TITLE
Fix finish new member

### DIFF
--- a/core/admin/MemberAdmin.py
+++ b/core/admin/MemberAdmin.py
@@ -23,7 +23,11 @@ class MemberAdmin(ViewableModelAdmin, BaseUserAdmin):
     add_fieldsets = (
         (None, {
             'classes': ('wide',),
-            'fields': ('username', 'password1', 'password2', 'rfid'),
+            'fields': ('username', 'password1', 'password2'),
+        }),
+        ('Staff Use Only', {
+            'classes': ('wide',),
+            'fields': ('membership', 'rfid'),
         }),
     )
     fieldsets = (

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -24,31 +24,71 @@ class MemberCreationForm(forms.ModelForm):
     and templates may not be present.
     """
 
+    # TODO: Make these either editable in the admin or be sourced externally
+    membership_choices = (
+        ("60", "$60 - Full Year New"),
+        ("40", "$40 - Full Year Returning"),
+        ("30", "$30 - One Quarter New"),
+        ("20", "$20 - One Quarter Returning")
+    )
+
     username = forms.EmailField(label='Email')
-    rfid = RFIDField(label='RFID')
-    # membership_rfid = forms.CharField(label="Membership RFID", max_length=10, widget=forms.TextInput)
-    password1 = forms.CharField(label='Password', widget=forms.PasswordInput)
-    password2 = forms.CharField(label='Confirm Password', widget=forms.PasswordInput)
+    rfid = RFIDField(
+        label='RFID',
+        help_text='If you\'re renewing, this will replace your current rfid tag'
+    )
+    password1 = forms.CharField(
+        label='Password',
+        widget=forms.PasswordInput,
+        help_text="You can skip this if you're renewing",
+        required=False
+    )
+    password2 = forms.CharField(
+        label='Confirm Password',
+        widget=forms.PasswordInput,
+        help_text="You can skip this if you're renewing",
+        required=False
+    )
+    membership = forms.ChoiceField(label="Membership Payment", choices=membership_choices)
+
+    membership_duration = 0
+    referenced_member = None
 
     class Meta:
         model = Member
-        fields = ('username', 'rfid', 'password1', 'password2',)
+        fields = ('username', 'password1', 'password2', 'membership', 'rfid')
 
     def clean_username(self):
         email = self.cleaned_data['username']
-        # If a member exists with this email, raise a validation error
+
+        # If a member exists with this email, we will be extendign their membership, so save them for future reference
         current = Member.objects.filter(email=email)
         if current:
-            raise forms.ValidationError("The email '{email}' is already in use!".format(email=email))
+            self.referenced_member = current[0]
+
         return email
 
     def clean_rfid(self):
         rfid = self.cleaned_data['rfid']
-        if len(rfid) != 10:
-            raise forms.ValidationError("This is not a valid 10 digit RFID!")
+
         if rfid in get_all_rfids():
             raise forms.ValidationError("This RFID is already in use!")
+
+        # If a member is renewing, the RFID can either be a new rfid, or empty
+        if self.referenced_member and not (len(rfid) == 0 or len(rfid) == 10):
+            raise forms.ValidationError
+
+        # If a member is not renewing, then rfid must be present
+        if len(rfid) != 10:
+            raise forms.ValidationError("This is not a valid 10 digit RFID!")
+
         return rfid
+
+    def clean_password1(self):
+        """Passwords are required if the member is new"""
+        password = self.cleaned_data['password1']
+        if not self.referenced_member and not password:
+            raise forms.ValidationError("Password is required when you're signing up")
 
     def clean_password2(self):
         # Check that the two password entries match
@@ -57,6 +97,33 @@ class MemberCreationForm(forms.ModelForm):
         if password1 and password2 and password1 != password2:
             raise forms.ValidationError("Passwords don't match")
         return password2
+
+    def clean_membership(self):
+        """
+        Convert the membership selection into a timedelta, and verify it is valid for the members current status
+        """
+        selection = self.cleaned_data['membership']
+
+        # Convert the membership selection into a timedelta
+        if selection == "60" or selection == "40":
+            self.membership_duration = timedelta(days=365)
+        elif selection == "30" or selection == "20":
+            self.membership_duration = timedelta(days=90)
+        else:
+            raise forms.ValidationError("Invalid membership choice!")
+
+        if self.is_new_membership(selection) and self.referenced_member:
+            raise forms.ValidationError(
+                "A member with this email already exists! Make sure you selected the right membership!")
+        elif not self.is_new_membership(selection) and not self.referenced_member:
+            raise forms.ValidationError(
+                "Could not find the member! Please make sure you typed the email correctly!"
+            )
+
+    @staticmethod
+    def is_new_membership(membership):
+        """Returns true if the membership selection corresponds to a new member signing up"""
+        return membership == "30" or membership == "60"
 
     def save(self, commit=True):
         """
@@ -70,8 +137,15 @@ class MemberCreationForm(forms.ModelForm):
         email = self.cleaned_data['username']
         rfid = self.cleaned_data['rfid']
         password = self.cleaned_data['password1']
-        duration = timedelta(days=90)
-        member = Member.objects.create_member(email, rfid, duration, password)
+        duration = self.membership_duration
+
+        # Depending on if this member exists or not, either create a new member, or just extend the membership
+        if self.referenced_member:
+            member = self.referenced_member
+            member.extend_membership(duration, )
+        else:
+            member = Member.objects.create_member(email, rfid, duration, password)
+
         finish_url = WEB_BASE + reverse("admin:core_member_finish", kwargs={'pk': member.pk})
         member.send_intro_email(finish_url)
         return member

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -26,10 +26,10 @@ class MemberCreationForm(forms.ModelForm):
 
     # TODO: Make these either editable in the admin or be sourced externally
     membership_choices = (
-        ("60", "$60 - Full Year New"),
-        ("40", "$40 - Full Year Returning"),
-        ("30", "$30 - One Quarter New"),
-        ("20", "$20 - One Quarter Returning")
+        ("year_new",        "$60 - Full Year New"),
+        ("year_return",     "$40 - Full Year Returning"),
+        ("quarter_new",     "$30 - One Quarter New"),
+        ("quarter_return",  "$20 - One Quarter Returning")
     )
 
     username = forms.EmailField(label='Email')
@@ -106,9 +106,9 @@ class MemberCreationForm(forms.ModelForm):
         selection = self.cleaned_data['membership']
 
         # Convert the membership selection into a timedelta
-        if selection == "60" or selection == "40":
+        if "year" in selection:
             self.membership_duration = timedelta(days=365)
-        elif selection == "30" or selection == "20":
+        elif "quarter" in selection:
             self.membership_duration = timedelta(days=90)
         else:
             raise forms.ValidationError("Invalid membership choice!")
@@ -124,7 +124,7 @@ class MemberCreationForm(forms.ModelForm):
     @staticmethod
     def is_new_membership(membership):
         """Returns true if the membership selection corresponds to a new member signing up"""
-        return membership == "30" or membership == "60"
+        return "new" in membership
 
     def save(self, commit=True):
         """

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -35,7 +35,8 @@ class MemberCreationForm(forms.ModelForm):
     username = forms.EmailField(label='Email')
     rfid = RFIDField(
         label='RFID',
-        help_text='If you\'re renewing, this will replace your current rfid tag'
+        help_text='If you\'re renewing, this will replace your current rfid tag',
+        required=False
     )
     password1 = forms.CharField(
         label='Password',
@@ -79,7 +80,7 @@ class MemberCreationForm(forms.ModelForm):
             raise forms.ValidationError
 
         # If a member is not renewing, then rfid must be present
-        if len(rfid) != 10:
+        if not self.referenced_member and len(rfid) != 10:
             raise forms.ValidationError("This is not a valid 10 digit RFID!")
 
         return rfid

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -143,7 +143,7 @@ class MemberCreationForm(forms.ModelForm):
         # Depending on if this member exists or not, either create a new member, or just extend the membership
         if self.referenced_member:
             member = self.referenced_member
-            member.extend_membership(duration, )
+            member.extend_membership(duration, rfid)
         else:
             member = Member.objects.create_member(email, rfid, duration, password)
 

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -143,7 +143,7 @@ class MemberCreationForm(forms.ModelForm):
         # Depending on if this member exists or not, either create a new member, or just extend the membership
         if self.referenced_member:
             member = self.referenced_member
-            member.extend_membership(duration, rfid)
+            member.extend_membership(duration, rfid=rfid, password=password)
         else:
             member = Member.objects.create_member(email, rfid, duration, password)
 

--- a/core/forms/fields/RFIDField.py
+++ b/core/forms/fields/RFIDField.py
@@ -16,7 +16,7 @@ class RFIDField(forms.CharField):
     def to_python(self, value):
         """Validate the RFID string is in fact a valid RFID"""
 
-        if not value.isdigit():
+        if value and not value.isdigit():
             raise ValidationError("RFIDs may only contain the digits 0-9")
 
         # If no errors were raised, just let the to_python method of CharField do the actual work.

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -180,6 +180,11 @@ class Member(AbstractBaseUser):
         self.group = Group.objects.get(name="Member")
         return self
 
+    def extend_membership(self, duration):
+        self.group = Group.objects.get(name="Just Joined")
+        self.date_expires += duration
+        return self
+
     def send_email(self, title, body, from_email='system@excursionclubucsb.org'):
         """Sends an email to the member"""
         send_mail(title, body, from_email, [self.email], fail_silently=False)

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -180,14 +180,17 @@ class Member(AbstractBaseUser):
         self.group = Group.objects.get(name="Member")
         return self
 
-    def extend_membership(self, duration, rfid):
-        """Add the given amount of time to this member's membership, and optionally update their rfid"""
+    def extend_membership(self, duration, rfid='', password=''):
+        """Add the given amount of time to this member's membership, and optionally update their rfid and password"""
 
         self.group = Group.objects.get(name="Just Joined")
         self.date_expires += duration
 
         if rfid:
             self.rfid = rfid
+
+        if password:
+            self.set_password(password)
 
         return self
 

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -110,7 +110,7 @@ class Member(AbstractBaseUser):
     certifications = models.ManyToManyField(Certification)
 
     USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = ['rfid', 'date_expires']
+    REQUIRED_FIELDS = ['date_expires']
 
     @property
     def is_staff(self):

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -180,9 +180,15 @@ class Member(AbstractBaseUser):
         self.group = Group.objects.get(name="Member")
         return self
 
-    def extend_membership(self, duration):
+    def extend_membership(self, duration, rfid):
+        """Add the given amount of time to this member's membership, and optionally update their rfid"""
+
         self.group = Group.objects.get(name="Just Joined")
         self.date_expires += duration
+
+        if rfid:
+            self.rfid = rfid
+
         return self
 
     def send_email(self, title, body, from_email='system@excursionclubucsb.org'):


### PR DESCRIPTION
Added handling of various membership options on the add member page

Up until now, the add member page didn't actually handle various membership options (OOPS). It can now handle both quarter and year long memberships, and has slightly different behavior for new and returning members. For new members, either the $60 or $30 options must be selected, and all information is required. For returning members, either the $40 or $20 option must be selected, and only email and membership is required; inputting an RFID will replace the current RFID. Entering a new password (1 and 2 must match) as a returning member will reset your password. Error messages are written to suggest the most common (as I'd imagine) errors that could cause each type of validation error, and suggest fixes.