### PR TITLE
Moved min_required_certs to geartype

### DIFF
--- a/core/models/GearModels.py
+++ b/core/models/GearModels.py
@@ -177,6 +177,14 @@ class GearType(models.Model):
     #: The department to which this type of gear belongs (roughly corresponds to STL positions)
     department = models.ForeignKey(Department, on_delete=models.CASCADE)
 
+    #: All the certifications that a member must posses to be allowed to check out this gear
+    min_required_certs = models.ManyToManyField(
+        Certification,
+        verbose_name="Minimal Certifications Required for Rental",
+        blank=True,
+        default=None,
+    )
+
     #:
     data_fields = models.ManyToManyField(CustomDataField)
 
@@ -258,9 +266,6 @@ class Gear(models.Model):
     ]
     #: The status determines what transactions the gear can participate in and where it is visible
     status = models.IntegerField(choices=status_choices)
-
-    #: All the certifications that a member must posses to be allowed to check out this gear
-    min_required_certs = models.ManyToManyField(Certification, verbose_name="Minimal Certifications Required for Rental")
 
     #: Who currently has this piece of gear. If null, then the gear is not checked out
     checked_out_to = models.ForeignKey(Member, blank=True, null=True, on_delete=models.SET_NULL)

--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -42,13 +42,14 @@ def validate_rfid(rfid):
 def validate_required_certs(member, gear):
     """Validate that the member has all the certifications required to check out this piece of gear."""
     missing_certs = []
-    for cert_required in gear.min_required_certs.all():
+    for cert_required in gear.gear_type.min_required_certs.all():
         if cert_required not in member.certifications.all():
             missing_certs.append(cert_required)
     if missing_certs:
         cert_names = [cert.title for cert in missing_certs]
-        raise ValidationError("{} is missing the following certifications: {}".format(
-            member.get_full_name, cert_names))
+        raise ValidationError(
+            f"{member.get_full_name()} is missing the following certifications: {cert_names}"
+        )
 
 
 class TransactionManager(models.Manager):


### PR DESCRIPTION
min_required_certs used to be on each piece of gear, which doesn't make sense. 

Moved it to gear_type, and updated the validator for having the min required certs in Transactions

need to run: makemigrations and migrate, but compatible to master with no issues