### PR TITLE
Fix duration for renewing memberships

### DIFF
--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -259,7 +259,7 @@ class Member(AbstractBaseUser):
 
     def has_module_perms(self, app_label):
         """This is required by django, determine whether the user is allowed to view the app"""
-        return Truet
+        return True
 
 
 class Staffer(models.Model):

--- a/core/models/MemberModels.py
+++ b/core/models/MemberModels.py
@@ -216,7 +216,11 @@ class Member(AbstractBaseUser):
         """Add the given amount of time to this member's membership, and optionally update their rfid and password"""
 
         self.group = Group.objects.get(name="Just Joined")
-        self.date_expires += duration
+
+        if self.group.name == "Expired":
+            self.date_expires = now() + duration
+        else:
+            self.date_expires += duration
 
         if rfid:
             self.rfid = rfid
@@ -255,7 +259,7 @@ class Member(AbstractBaseUser):
 
     def has_module_perms(self, app_label):
         """This is required by django, determine whether the user is allowed to view the app"""
-        return True
+        return Truet
 
 
 class Staffer(models.Model):


### PR DESCRIPTION
Renewing memberships used to add to the past expiration even if already expired.
Changed so expired members can renew for 365 from now.