### PR TITLE
Fix 500 error when saving gear

### DIFF
--- a/core/models/TransactionModels.py
+++ b/core/models/TransactionModels.py
@@ -362,7 +362,7 @@ class TransactionManager(models.Manager):
         """
         gear = Gear.objects.get(rfid=gear_rfid)
 
-        member = Member.objects.get(authorizer_rfid)
+        member = Member.objects.get(rfid=authorizer_rfid)
         if not member.has_permission('change_gear'):
             raise ValidationError("You don't have the permission to change gear!")
 


### PR DESCRIPTION
When gear is changed in admin and saved, an override transaction is created. The way this transaction was looking up the person who authorized it at the time was broken