### PR TITLE
Fix gear search

### DIFF
--- a/core/admin/GearAdmin.py
+++ b/core/admin/GearAdmin.py
@@ -19,7 +19,7 @@ class GearAdmin(ViewableModelAdmin):
     list_filter = ('status', "geartype__department", "geartype")
 
     # Choose which fields can be searched for
-    search_fields = ('name', 'rfid', "checked_out_to__first_name", "checked_out_to__last_name")
+    search_fields = ('geartype__name', 'gear_data', 'rfid', 'checked_out_to__first_name', 'checked_out_to__last_name')
 
     fieldsets = [
         ('Gear Info', {


### PR DESCRIPTION
The gear search function had 'name' as a searchable field. This is a property of the python object, and not a database field. Since django search queries are compiled to SQL, this breaks. Most of the same functionality was restored by searching over geartype names and gear data