### PR TITLE
Fix atribute erro in member forms

### DIFF
--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -261,7 +261,7 @@ class MemberFinishForm(forms.ModelForm):
         member.last_name = self.cleaned_data['last_name']
         member.phone_number = self.cleaned_data['phone_number']
         member.image = self.cleaned_data['image']
-        member = member.promote_to_active()
+        member.promote_to_active()
 
         member.save()
         return member


### PR DESCRIPTION
Member promote to active doesn't return anything, so it was setting member to none