### PR TITLE
Hotfix: API disappeared

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,7 @@
 from api.views import CheckIfActiveMemberView
 from django.urls import include, path
 
-app_name = 'kiosk'
+app_name = 'api'
 urlpatterns = [
     path('memberRFIDcheck/<str:rfid>', CheckIfActiveMemberView.as_view(), name='memberRFIDcheck'),
 ]

--- a/helper_scripts/build_permissions.py
+++ b/helper_scripts/build_permissions.py
@@ -5,6 +5,7 @@ from core.models.MemberModels import Member, Staffer
 from core.models.QuizModels import Answer, Question
 from core.models.TransactionModels import Transaction
 from core.models.FileModels import AlreadyUploadedImage
+from api.models import MemberRFIDCheck
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError, transaction
@@ -27,6 +28,8 @@ group_type = ContentType.objects.get_for_model(Group)
 question_type = ContentType.objects.get_for_model(Question)
 answer_type = ContentType.objects.get_for_model(Answer)
 image_type = ContentType.objects.get_for_model(AlreadyUploadedImage)
+rfid_check_type = ContentType.objects.get_for_model(MemberRFIDCheck)
+
 
 def build_all():
     """Build all the groups. Must be done in ascending order of power"""
@@ -133,6 +136,11 @@ def build_staffer():
         codename="add_alreadyuploadedimage",
         name="Can add and Already Uploaded Image",
         content_type=image_type
+    )
+    add_permission(
+        codename="view_memberrfidcheck",
+        name="View member RFID check log",
+        content_type=rfid_check_type
     )
     add_group("Staff", all_permissions)
 


### PR DESCRIPTION
The entire API app dissappeared, turns out I accidentally deleted the permissions to view the API when merging. 

Fixed both in the code (for dev purposes, build_permissions adds the appropriate perm) and by manually editing the SQL. 

This PR mostly is the dev fix.