### PR TITLE
Fix access to private S3 files

### DIFF
--- a/ExCSystem/settings/storage_backends.py
+++ b/ExCSystem/settings/storage_backends.py
@@ -3,4 +3,6 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 class MediaStorage(S3Boto3Storage):
     location = 'media'
+    default_acl = 'private'
     file_overwrite = False
+    custom_domain = False


### PR DESCRIPTION
Depends on https://github.com/ExcursionClub/ExCSystem/pull/185

Allow access to private S3 files.
Before this private images would not show up in profiles