### PR TITLE
Fixed the way rfids are passed 

### DIFF
--- a/kiosk/urls.py
+++ b/kiosk/urls.py
@@ -7,7 +7,7 @@ app_name = 'kiosk'
 urlpatterns = [
     path('', views.HomeView.as_view(), name='home'),
     path('', include('django.contrib.auth.urls')),
-    path('gear/<int:rfid>/', views.GearView.as_view(), name='gear'),
-    path('member/<int:rfid>/', views.CheckOutView.as_view(), name='check_out'),
-    path('retag-gear/<int:rfid>/', views.RetagGearView.as_view(), name='retag_gear')
+    path('gear/<slug:rfid>/', views.GearView.as_view(), name='gear'),
+    path('member/<slug:rfid>/', views.CheckOutView.as_view(), name='check_out'),
+    path('retag-gear/<slug:rfid>/', views.RetagGearView.as_view(), name='retag_gear')
 ]


### PR DESCRIPTION
RFIDs in the kiosk were being passed between views as int in urls.py This ended up removing any 0 at the beginning of the rfid. Changed int to slug and things now work well.

