### PR TITLE
Remove requirements dir

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,0 @@
-django==2.1.1
-django-phonenumber-field==2.0.1
-names==0.3.0
-progressbar2==3.38.0
-pillow==5.2.0
-celery==4.2.1
-django-celery-beat==1.1.1


### PR DESCRIPTION
Since we installed pipenv, our dependencies are stored in the pipfile. Therefore, we no longer need (or want) the requirements dir

This will resolve security alert: [django-vunerability](https://github.com/ExcursionClub/ExCSystem/network/alert/requirements/base.txt/django/open)
This alert is not valid because we don't actually use that version of django
