### PR TITLE
Change notifications link to detail page

### DIFF
--- a/core/admin/ViewableAdmin.py
+++ b/core/admin/ViewableAdmin.py
@@ -1,5 +1,4 @@
 from functools import update_wrapper
-
 from core.views.common import ModelDetailView
 from core.views.ViewList import RestrictedViewList
 from django.contrib.admin import ModelAdmin
@@ -147,3 +146,17 @@ class ViewableModelAdmin(ModelAdmin):
         # match any member url containing an id
         urlpatterns = super(ViewableModelAdmin, self).get_urls()
         return view_url + urlpatterns
+
+    def response_change(self, request, obj):
+        """
+        Fix linking to detail page in change messages
+
+        This function is called after a model is edited in the admin. The overridden function adds a change message
+        into the template, which includes a link to the change page. This is because the link is set to re-direct back
+        to the page the post request was made to (i.e. the change page). Here we just override that parameter to be a
+        link to the detail page before allowing execution to proceed as normal
+        """
+
+        request.path = request.path.replace("/change/", "/detail/")
+        return super(ViewableModelAdmin, self).response_change(request, obj)
+

--- a/core/templates/admin/index.html
+++ b/core/templates/admin/index.html
@@ -39,8 +39,6 @@
 
 {% if app_list %}
 
-        NOTE: TEMP OVERRIDE OF INDEX TEMPLATE. SOMEONE YELL AT ME IF THIS IS STILL UP! - Tomek
-
     {% for app in app_list %}
         <div class="app-{{ app.app_label }} module">
         <table>

--- a/core/templates/admin/index.html
+++ b/core/templates/admin/index.html
@@ -1,0 +1,115 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
+
+{% block extrahead %}
+<script>
+    document.addEventListener('DOMContentLoaded',
+        function () {
+            console.log("Trying to switch up links...");
+            var recent_actions = document.getElementById("recent-actions-module");
+            var old_html = recent_actions.innerHTML;
+
+            // Replace links of the form /admin/<app_name>/<model_name>/<pk>/change/
+            // to now be of the form /admin/<app_name>/<model_name>/<pk>/detail/
+            var new_html = old_html.replace(
+                /\/admin\/([A-Za-z]+\/[A-Za-z]+\/[0-9]*)\/change\//g,
+                '/admin/$1/detail/'
+            );
+            console.log(new_html);
+            recent_actions.innerHTML = new_html;
+        }
+    )
+
+</script>
+{% endblock %}
+
+{% block coltype %}colMS{% endblock %}
+
+{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+
+
+
+<div id="content-main">
+
+{% if app_list %}
+
+        NOTE: TEMP OVERRIDE OF INDEX TEMPLATE. SOMEONE YELL AT ME IF THIS IS STILL UP! - Tomek
+
+    {% for app in app_list %}
+        <div class="app-{{ app.app_label }} module">
+        <table>
+        <caption>
+            <a href="{{ app.app_url }}" class="section" title="{% blocktrans with name=app.name %}Models in the {{ name }} application{% endblocktrans %}">{{ app.name }}</a>
+        </caption>
+        {% for model in app.models %}
+            <tr class="model-{{ model.object_name|lower }}">
+            {% if model.admin_url %}
+                <th scope="row"><a href="{{ model.admin_url }}">{{ model.name }}</a></th>
+            {% else %}
+                <th scope="row">{{ model.name }}</th>
+            {% endif %}
+
+            {% if model.add_url %}
+                <td><a href="{{ model.add_url }}" class="addlink">{% trans 'Add' %}</a></td>
+            {% else %}
+                <td>&nbsp;</td>
+            {% endif %}
+
+            {% if model.admin_url %}
+                {% if model.view_only %}
+                <td><a href="{{ model.admin_url }}" class="viewlink">{% trans 'View' %}</a></td>
+                {% else %}
+                <td><a href="{{ model.admin_url }}" class="changelink">{% trans 'Change' %}</a></td>
+                {% endif %}
+            {% else %}
+                <td>&nbsp;</td>
+            {% endif %}
+            </tr>
+        {% endfor %}
+        </table>
+        </div>
+    {% endfor %}
+{% else %}
+    <p>{% trans "You don't have permission to view or edit anything." %}</p>
+{% endif %}
+</div>
+{% endblock %}
+
+{% block sidebar %}
+<div id="content-related">
+    <div class="module" id="recent-actions-module">
+        <h2>{% trans 'Recent actions' %}</h2>
+        <h3>{% trans 'My actions' %}</h3>
+            {% load log %}
+            {% get_admin_log 10 as admin_log for_user user %}
+            {% if not admin_log %}
+            <p>{% trans 'None available' %}</p>
+            {% else %}
+            <ul class="actionlist">
+            {% for entry in admin_log %}
+            <li class="{% if entry.is_addition %}addlink{% endif %}{% if entry.is_change %}changelink{% endif %}{% if entry.is_deletion %}deletelink{% endif %}">
+                {% if entry.is_deletion or not entry.get_admin_url %}
+                    {{ entry.object_repr }}
+                {% else %}
+                    {{entry.str}}
+                    <a href="{{ entry.get_admin_url}}">{{ entry.object_repr }}</a>
+                {% endif %}
+                <br>
+                {% if entry.content_type %}
+                    <span class="mini quiet">{% filter capfirst %}{{ entry.content_type }}{% endfilter %}</span>
+                {% else %}
+                    <span class="mini quiet">{% trans 'Unknown content' %}</span>
+                {% endif %}
+            </li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This change has two parts. The first is to the links in the recent actions on the admin index, the second is to the links in messages shown directly after a change. 

### Recent Actions
Turns out this is surprisingly difficult to change via python. 

The recent actions are generated from django's LogEntry model, which has an entry created on every change to the database made via the admin. Unlike the rest of django's classes, this model cannot be cleanly sub-classed without re-writing almost all of the database interaction code. So our options were:
1) Change the code in the django source, but this will have massive distribution issues
2) Re-implement the entire django logging system to use a different logging class. This would be a massive project, would require every class to explicitly reference the new history, and would be a migration nightmare
3) Monkey patch a new get_admin_url method as the admin action log as it is loaded into the template. It's hacky as all hell and would be a nightmare to debug
4) Just use js and regex to fix the links after the DOM is loaded

I went with 4.

The javascript function is included in the 'extra head' block on the admin_index template. It selects out the section of the DOM with id 'recent-actions-module' and replaces all links to change pages with links to the same detail pages.

### Change messages

This one is a lot cleaner. The response_change function is called after a post request to the /change/ page. It then inserts a message that contains a link back to the page the request was originally made to (the change page). To make the message link to the detail page, we simply replace the request.path variable to be a link to the /detail/ page.
Although this seems really hacky, this variable is only used once, and the request is garbage collected once the function completes, so there shouldn't be any issues. 

Partial fix of #257