### PR TITLE
Fix RFID Submit

### DIFF
--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -75,7 +75,7 @@ class MemberCreationForm(forms.ModelForm):
         rfid = self.cleaned_data["rfid"]
 
         if rfid in get_all_rfids():
-            raise forms.ValidationError("This RFID is already in use!")
+            raise forms.ValidationError(f"The RFID '{rfid}' is already in use!")
 
         # If a member is renewing, the RFID can either be a new rfid, or empty
         if self.referenced_member and not (len(rfid) == 0 or len(rfid) == 10):
@@ -83,7 +83,7 @@ class MemberCreationForm(forms.ModelForm):
 
         # If a member is not renewing, then rfid must be present
         if not self.referenced_member and len(rfid) != 10:
-            raise forms.ValidationError("This is not a valid 10 digit RFID!")
+            raise forms.ValidationError(f"'{rfid}' is not a valid 10 digit RFID!")
 
         return rfid
 

--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -35,7 +35,7 @@ class MemberCreationForm(forms.ModelForm):
     username = forms.EmailField(label="Email")
     rfid = RFIDField(
         label="RFID",
-        help_text="If you're renewing, this will replace your current rfid tag",
+        help_text="&nbsp &nbsp &nbsp If you're renewing, this will replace your current rfid tag",
         required=False,
     )
     password1 = forms.CharField(

--- a/core/forms/fields/RFIDField.py
+++ b/core/forms/fields/RFIDField.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.forms import ValidationError
+from core.forms.widgets import RFIDWidget
 
 
 class RFIDField(forms.CharField):
@@ -7,7 +8,7 @@ class RFIDField(forms.CharField):
     Wrapper around CharField changing the default widget and adding validation
     """
 
-    # widget = RFIDWidget
+    widget = RFIDWidget
 
     def __init__(self, max_length=10, min_length=10, **kwargs):
         super().__init__(max_length=max_length, min_length=min_length, **kwargs)

--- a/core/forms/widgets.py
+++ b/core/forms/widgets.py
@@ -11,6 +11,7 @@ class RFIDWidget(widgets.TextInput):
     revert_button_text = "Hide Manual Input"
     scan_rfid_button_text = "Click to Scan RFID"
     template_name = "widgets/rfid.html"
+    max_length = 10
 
     def __init__(self, attrs=None):
         # TODO: Add option to modify default values of class vars here
@@ -24,6 +25,7 @@ class RFIDWidget(widgets.TextInput):
         widget["allow_revert"] = self.allow_revert
         widget["revert_button_text"] = self.revert_button_text
         widget["scan_rfid_button_text"] = self.scan_rfid_button_text
+        widget["max_length"] = self.max_length
 
         context["widget"] = widget
         return context

--- a/core/templates/widgets/dynamicTwoState.html
+++ b/core/templates/widgets/dynamicTwoState.html
@@ -12,18 +12,28 @@
     }
 
     {% block script %}{% endblock %}
+
+
 </script>
+<style>
+    .stacked {
+        position: absolute;
+        background: white;
+    }
+</style>
 
 <div>
-    {% block shared_display %} {% endblock %}
-</div>
-<div id="original_display">
-        {% block original_display %}{% endblock %}
-        <input id="change_button" type="button" value="{{ widget.change_button_text }}" onclick="changeMode()">
-</div>
-<div id="changed_display" hidden>
-    {% block changed_display %}{% endblock %}
-    {% if widget.allow_revert %}
-        <input id="revert_button" type="button" value="{{ widget.revert_button_text }}" onclick="revertMode()">
-    {% endif %}
+    <div class="stacked" >
+        {% block shared_display %} {% endblock %}
+    </div>
+    <div class="stacked" id="original_display">
+            {% block original_display %}{% endblock %}
+            <input id="change_button" type="button" value="{{ widget.change_button_text }}" onclick="changeMode()">
+    </div>
+    <div class="stacked" id="changed_display" hidden>
+        {% block changed_display %}{% endblock %}
+        {% if widget.allow_revert %}
+            <input id="revert_button" type="button" value="{{ widget.revert_button_text }}" onclick="revertMode()">
+        {% endif %}
+    </div>
 </div>

--- a/core/templates/widgets/rfid.html
+++ b/core/templates/widgets/rfid.html
@@ -2,6 +2,16 @@
 
 {% block script %}
 
+    window.addEventListener(
+        'keydown', function(e){
+            if(e.keyIdentifier=='U+000A'||e.keyIdentifier=='Enter'||e.keyCode==13){
+                if(e.target.nodeName=='INPUT'&&e.target.type=='text'){
+                    e.preventDefault();
+                    return false;
+                }
+            }
+        },true);
+
     function focusRFID() {
         $("#rfid").focus();
     }

--- a/core/templates/widgets/rfid.html
+++ b/core/templates/widgets/rfid.html
@@ -27,10 +27,9 @@
          $("#rfid").focus();
     }
 
-    $("#rfid").on("input", function(e) {
-        console.debug($("#rfid").value);
-        $("#rfid_disp").value = $("#rfid").value;
-    });
+    function updateValue(input) {
+        document.getElementById("rfid_disp").innerHTML = "New RFID:  " + input.value;
+    }
 
 
 </script>
@@ -41,9 +40,10 @@
     }
 </style>
 
-<div>
+<div style="padding-bottom: 60px;">
     <div class="stacked">
-        <input type="text" id="rfid" maxlength="{{ widget.max_length }}}">
+        <input type="text" id="rfid" maxlength="{{ widget.max_length }}}"
+               onkeyup="updateValue(this);" oninput="updateValue(this);">
     </div>
     <div class="stacked" id="original_display">
         <input type="button" id="click_to_scan_button" value="{{ widget.scan_rfid_button_text }}" onclick="focusRFID()">

--- a/core/templates/widgets/rfid.html
+++ b/core/templates/widgets/rfid.html
@@ -1,13 +1,18 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script>
+
     function changeMode() {
             $("#original_display").hide();
             $("#changed_display").show();
+            $("#change-parent").addClass("small-padding");
+            $("#change-parent").removeClass("big-padding");
     }
 
     function revertMode() {
         $("#changed_display").hide();
         $("#original_display").show();
+        $("#change-parent").addClass("big-padding");
+        $("#change-parent").removeClass("small-padding")
     }
 
     window.addEventListener('keydown',
@@ -38,9 +43,15 @@
         position: absolute;
         background: white;
     }
+    .big-padding {
+        padding-bottom: 52px;
+    }
+    .small-padding {
+        padding-bottom: 15px;
+    }
 </style>
 
-<div style="padding-bottom: 60px;">
+<div id='change-parent' class="big-padding">
     <div class="stacked">
         <input type="text" id="rfid" maxlength="{{ widget.max_length }}}"
                onkeyup="updateValue(this);" oninput="updateValue(this);">

--- a/core/templates/widgets/rfid.html
+++ b/core/templates/widgets/rfid.html
@@ -29,7 +29,7 @@
 
 
     function focusRFID() {
-         $("#rfid").focus();
+         $("#id_rfid").focus();
     }
 
     function updateValue(input) {
@@ -53,8 +53,12 @@
 
 <div id='change-parent' class="big-padding">
     <div class="stacked">
-        <input type="text" id="rfid" maxlength="{{ widget.max_length }}}"
-               onkeyup="updateValue(this);" oninput="updateValue(this);">
+        <input type="text" name="{{ widget.name }}" onkeyup="updateValue(this);" oninput="updateValue(this);"
+               {% if widget.value != None %}
+                    value="{{ widget.value|stringformat:'s' }}"
+               {% endif %}
+               {% include "django/forms/widgets/attrs.html" %}
+        >
     </div>
     <div class="stacked" id="original_display">
         <input type="button" id="click_to_scan_button" value="{{ widget.scan_rfid_button_text }}" onclick="focusRFID()">

--- a/core/templates/widgets/rfid.html
+++ b/core/templates/widgets/rfid.html
@@ -1,30 +1,58 @@
-{% extends "widgets/dynamicTwoState.html" %}
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script>
+    function changeMode() {
+            $("#original_display").hide();
+            $("#changed_display").show();
+    }
 
-{% block script %}
+    function revertMode() {
+        $("#changed_display").hide();
+        $("#original_display").show();
+    }
 
-    window.addEventListener(
-        'keydown', function(e){
+    window.addEventListener('keydown',
+        function(e){
             if(e.keyIdentifier=='U+000A'||e.keyIdentifier=='Enter'||e.keyCode==13){
                 if(e.target.nodeName=='INPUT'&&e.target.type=='text'){
                     e.preventDefault();
                     return false;
                 }
             }
-        },true);
+        },
+        true
+    );
+
 
     function focusRFID() {
-        $("#rfid").focus();
+         $("#rfid").focus();
     }
 
-{% endblock %}
+    $("#rfid").on("input", function(e) {
+        console.debug($("#rfid").value);
+        $("#rfid_disp").value = $("#rfid").value;
+    });
 
-{% block shared_display %}
-    <input id="rfid">
-{% endblock %}
 
-{% block original_display %}
-    <input type="button" id="click_to_scan_button" value="{{ widget.scan_rfid_button_text }}" onclick="focusRFID()">
-{% endblock %}
+</script>
+<style>
+    .stacked {
+        position: absolute;
+        background: white;
+    }
+</style>
 
-{% block changed_display %}
-{% endblock %}
+<div>
+    <div class="stacked">
+        <input type="text" id="rfid" maxlength="{{ widget.max_length }}}">
+    </div>
+    <div class="stacked" id="original_display">
+        <input type="button" id="click_to_scan_button" value="{{ widget.scan_rfid_button_text }}" onclick="focusRFID()">
+        <input id="change_button" type="button" value="{{ widget.change_button_text }}" onclick="changeMode()">
+        <div id="rfid_disp"></div>
+    </div>
+    <div id="changed_display" hidden>
+        {% if widget.allow_revert %}
+            <input id="revert_button" type="button" value="{{ widget.revert_button_text }}" onclick="revertMode()">
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
Work in progress to address #117

When an RFID is scanned, it "types" in the RFID number and then "presses" enter. By default this submits the form. Here we make the RFID widget squash enter key presses, and make the RFID widget quite a bit prettier