### PR TITLE
HOTFIX: Broken Add Member Page

### DIFF
--- a/core/admin/MemberAdmin.py
+++ b/core/admin/MemberAdmin.py
@@ -164,6 +164,8 @@ class MemberAdmin(ViewableModelAdmin, BaseUserAdmin):
         """Make it so only those who can make staffers be able to change a member's group"""
         if not request.user.has_permission('core.add_staffer'):
             return ('groups', )
+        else:
+            return ()
 
 
 class StafferAdmin(ViewableModelAdmin):


### PR DESCRIPTION
Anyone with add_staffer permission was getting NONE instead of [] (empty
list) for the readonly_fields attribute, leading to a crash. Now we
properly return () (empty tuple)