### PR TITLE
[HOTFIX] Fix server error on member edit profile page

### DIFF
--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -437,7 +437,8 @@ class MemberChangeForm(forms.ModelForm):
         return groups
 
     def save(self, commit=True):
-        self.instance.move_to_group(self.cleaned_data["group"])
+        if 'group' in self.cleaned_data:
+            self.instance.move_to_group(self.cleaned_data["group"])
         return super(MemberChangeForm, self).save(commit=commit)
 
 


### PR DESCRIPTION
When saving data from the form, we always tried to move a member to the
appropriate group. On the profileedit page for regular members, 'group' is not
a form element, so we got a KeyError when trying to find group