### PR TITLE
Fix server 500 error when clearing current image.

### DIFF
--- a/core/forms/MemberForms.py
+++ b/core/forms/MemberForms.py
@@ -268,7 +268,7 @@ class MemberFinishForm(forms.ModelForm):
         """Ensures that the image is of a sufficiently small size before it gets uploaded"""
         image = self.cleaned_data["image"]
 
-        if image.name == DEFAULT_IMG:
+        if not image or image.name == DEFAULT_IMG:
             raise forms.ValidationError("Please upload your own profile picture!")
         if not hasattr(image, "size"):
             raise forms.ValidationError("Please upload a profile picture!")


### PR DESCRIPTION
Previously, when someone checked the 'clear' button on the image
selection widget, the widget returned 'False'. Since we were assuming
that the returned value would be an image, this caused an attribute
error. Now we will raise a validation error, which will display in the
form instead of crashing