### PR TITLE
Show all active members

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,4 +1,4 @@
-from api.views import CheckIfActiveMemberView
+from api.views import CheckIfActiveMemberView, ActiveMemberView
 from django.urls import include, path
 
 app_name = "api"
@@ -7,5 +7,10 @@ urlpatterns = [
         "memberRFIDcheck/<str:rfid>",
         CheckIfActiveMemberView.as_view(),
         name="memberRFIDcheck",
+    ),
+    path(
+        "active_members",
+        ActiveMemberView.as_view(),
+        name="all_active_members"
     )
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,10 +1,31 @@
 from api.models import MemberRFIDCheck
+from core.models.MemberModels import Member
 from core.views.common import ModelDetailView
 from core.views.ViewList import RestrictedViewList
+from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
+from django.urls import reverse
+from django.views.generic import TemplateView
 from django.http.response import HttpResponse
 from django.views.generic.base import View
 
 # Create your views here.
+
+
+class ActiveMemberView(LoginRequiredMixin, UserPassesTestMixin,TemplateView):
+
+    template_name = "admin/api/active_members.html"
+
+    def test_func(self):
+        return self.request.user.has_permission('core.view_all_members')
+
+    def get_context_data(self, **kwargs):
+        context = super(ActiveMemberView, self).get_context_data(**kwargs)
+
+        members = Member.objects.all()
+        emails = [f"{member.email}\n" for member in members if member.is_active_member]
+
+        context['emails'] = emails
+        return context
 
 
 class CheckIfActiveMemberView(View):

--- a/excsystem/settings/development.py
+++ b/excsystem/settings/development.py
@@ -5,7 +5,10 @@ DEBUG = True
 STATIC_URL = "static/"
 MEDIA_URL = "media/"
 
-INSTALLED_APPS.append("minio_storage")
+INSTALLED_APPS.extend([
+    "minio_storage",
+    "django_extensions"
+])
 MEDIA_ROOT = os.path.join(BASE_DIR, MEDIA_URL)
 
 DEFAULT_FILE_STORAGE = "minio_storage.storage.MinioMediaStorage"


### PR DESCRIPTION
Currently not linked anywhere, but visiting <BASE>/api/active_members
will show a list of all the emails of active members. For security, this
view requires a login and the user to have the 'core.view_all_members'
permission.

Previously, the process to update the listserv was as follows:
1. SSH into the server
2. run the script to generate a file containing a list of alll active member emails
3. SCP that to your local machine
4. Manually log in to listserv and update the email list

Now, the process will be:
1. open <BASE>/api/active_members
2. Authenticate
3. Copy paste list of emails into a local txt file
4. Manually log in to listserv and update the email list