### PR TITLE
All member view fix

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -21,7 +21,7 @@ class ActiveMemberView(LoginRequiredMixin, UserPassesTestMixin,TemplateView):
     def get_context_data(self, **kwargs):
         context = super(ActiveMemberView, self).get_context_data(**kwargs)
 
-        members = Member.objects.all()
+        members = Member.objects.all().exclude(group='Expired')
         emails = [f"{member.email}\n" for member in members if member.is_active_member]
 
         context['emails'] = emails


### PR DESCRIPTION
Active membership status is determined in python by the permission system. This approach is flexible and reliable but slow. For production (with 9k rows) this took too long and timed out the heroku connection. We now filter out all expired members in the SQL query step, dramatically reducing the cumber of checks needed to be done in python with only a minimal decrease in flexibility

Thanks for the idea @romanova2 